### PR TITLE
Offer a retake on the scan crop dialog (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ cost per year, per km, and what's due next?*
 - Scan a receipt and it comes out flat. Scanning opens the camera directly, the
   server finds the document in the photo and flattens it, and you see the crop
   beside the photo as taken and choose which to keep. Nothing is stored until
-  you pick, so a detection that gets it wrong costs you a tap. If no document is
-  found, or the optional scanning dependency is not installed, the photo simply
-  attaches as taken. Detection runs on the server rather than in the browser
+  you pick, so a detection that gets it wrong costs you a tap. If the photo
+  itself did not come out, Retake reopens the camera on the spot rather than
+  making you start the scan again. If no document is found, or the optional
+  scanning dependency is not installed, you are offered the photo as taken or
+  another go at it. Detection runs on the server rather than in the browser
   precisely so that it does not depend on what phone you happen to be holding.
 
 **A status page per car**

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ TYRE_CORNERS = ("FL", "FR", "RL", "RR")
 BASELINE_NOTE = "Full tread when fitted"   # marks the check a tyre fitting writes for itself
 FUEL_TYPES = ("petrol", "diesel", "hybrid", "phev", "ev")
 
-APP_VERSION = "1.11.0"   # bump on release; shown on the home screen
+APP_VERSION = "1.12.0"   # bump on release; shown on the home screen
 
 app = FastAPI(title="Car Costs", version=APP_VERSION)
 

--- a/static/app.js
+++ b/static/app.js
@@ -351,7 +351,8 @@ async function showCar(id, year) {
     $(inp).addEventListener("change", async ev => {
       const file = ev.target.files[0];
       if (!file) return;
-      const doc = inp === "#doc-scan" ? await scanCrop(file) : file;
+      const doc = inp === "#doc-scan" ? await scanCrop(file, ev.target) : file;
+      if (doc === SCAN_RETAKE) return;   // scanCrop already reopened the camera
       if (!doc) { ev.target.value = ""; return; }
       try { await uploadDoc(`/api/cars/${id}/attachments`, doc, doc === file ? undefined : "scan.jpg"); showCar(id); }
       catch (e) { alert(e.message); }
@@ -370,9 +371,16 @@ async function uploadDoc(path, file, name) {
    the browser with a 9 MB OpenCV build and never once worked on a phone, which
    is the whole reason it moved. Picker-chosen files skip all of this.
 
-   Returns a cropped JPEG Blob, the original file, or null (cancelled). Anything
-   that goes wrong returns the original — a scan is never lost to this step. */
-async function scanCrop(file) {
+   Returns a cropped JPEG Blob, the original file, SCAN_RETAKE (#36, take the
+   photo again) or null (cancelled). Anything that goes wrong returns the
+   original — a scan is never lost to this step.
+
+   The dialog also opens when the server found nothing to crop, so that a bad
+   photo can be taken again instead of attaching silently. Nothing to crop is
+   not a failure though — a car part, a paint defect or crash damage is a whole
+   photo by design, so that path keeps "Attach as taken" as the main action. */
+const SCAN_RETAKE = Symbol("retake");
+async function scanCrop(file, input) {
   let crop = null;
   try {
     const fd = new FormData();
@@ -381,30 +389,38 @@ async function scanCrop(file) {
     if (!r.ok) return file;
     if ((r.headers.get("content-type") || "").startsWith("image/")) crop = await r.blob();
   } catch (e) { return file; }
-  if (!crop) return file;          // no document found, or the server has no scanner
 
-  const cropUrl = URL.createObjectURL(crop), fullUrl = URL.createObjectURL(file);
+  const cropUrl = crop ? URL.createObjectURL(crop) : null, fullUrl = URL.createObjectURL(file);
   return new Promise(resolve => {
     const dlg = document.createElement("dialog");
     dlg.className = "scan-dlg";
     dlg.innerHTML = `<h1>Crop scan</h1>
-      <p class="hint" style="margin:0 0 8px">Cropped to the document. Keep it, or attach the photo as taken.</p>
+      <p class="hint" style="margin:0 0 8px">${crop
+        ? "Cropped to the document. Keep it, or attach the photo as taken."
+        : "Nothing to crop here, so the whole photo goes up. Take it again if it did not come out."}</p>
       <div class="scan-pair">
-        <figure><img src="${cropUrl}" alt="Cropped scan"><figcaption>Cropped</figcaption></figure>
+        ${crop ? `<figure><img src="${cropUrl}" alt="Cropped scan"><figcaption>Cropped</figcaption></figure>` : ""}
         <figure><img src="${fullUrl}" alt="Photo as taken"><figcaption>As taken</figcaption></figure>
       </div>
-      <div class="dlg-actions"><button type="button" class="ghost" id="sc-cancel">Cancel</button>
-      <button type="button" class="ghost" id="sc-full">Full photo</button>
-      <button type="button" id="sc-crop">Use crop</button></div>`;
+      <div class="dlg-actions"><button type="button" class="ghost" id="sc-retake">Retake</button>
+      <button type="button" class="ghost" id="sc-full">${crop ? "Full photo" : "Attach as taken"}</button>
+      ${crop ? `<button type="button" id="sc-crop">Use crop</button>` : ""}</div>`;
     document.body.append(dlg);
     const finish = val => {
-      URL.revokeObjectURL(cropUrl); URL.revokeObjectURL(fullUrl);
+      if (cropUrl) URL.revokeObjectURL(cropUrl);
+      URL.revokeObjectURL(fullUrl);
       dlg.close(); dlg.remove(); resolve(val);
     };
-    $("#sc-cancel", dlg).addEventListener("click", () => finish(null));
+    $("#sc-retake", dlg).addEventListener("click", () => {
+      // Reopen from inside the click itself — a mobile browser refuses a file
+      // input opened any later. Clearing the value first is what lets the same
+      // photo fire `change` a second time.
+      if (input) { input.value = ""; input.click(); }
+      finish(SCAN_RETAKE);
+    });
     $("#sc-full", dlg).addEventListener("click", () => finish(file));
-    $("#sc-crop", dlg).addEventListener("click", () => finish(crop));
-    dlg.addEventListener("cancel", ev => { ev.preventDefault(); finish(null); });
+    if (crop) $("#sc-crop", dlg).addEventListener("click", () => finish(crop));
+    dlg.addEventListener("cancel", ev => { ev.preventDefault(); finish(null); });   // Esc abandons the scan
     dlg.showModal();
   });
 }
@@ -542,7 +558,8 @@ function attachmentsDialog(car, entry) {
     inp.addEventListener("change", async ev => {
       const file = ev.target.files[0];
       if (!file) return;
-      const doc = inp.classList.contains("att-scan") ? await scanCrop(file) : file;
+      const doc = inp.classList.contains("att-scan") ? await scanCrop(file, ev.target) : file;
+      if (doc === SCAN_RETAKE) return;   // scanCrop already reopened the camera
       if (!doc) { ev.target.value = ""; return; }
       try { await uploadDoc(`/api/entries/${entry.id}/attachments`, doc, doc === file ? undefined : "scan.jpg"); }
       catch (e) { alert(e.message); return; }
@@ -906,7 +923,10 @@ function entryDialog(car, cat, entry) {
   if (docInput) docInput.addEventListener("change", async ev => {
     const file = ev.target.files[0];
     if (!file) { scanBlob = null; return; }
-    scanBlob = await scanCrop(file);
+    const doc = await scanCrop(file, ev.target);
+    // A retake replaces the held photo rather than adding a second one.
+    if (doc === SCAN_RETAKE) { scanBlob = null; return; }
+    scanBlob = doc;
     if (!scanBlob) ev.target.value = "";
   });
   if (isFuel || isCharge) {

--- a/static/index.html
+++ b/static/index.html
@@ -102,6 +102,6 @@ button.clip.clip-empty { opacity: .35; }
 </head>
 <body>
 <div id="app"></div>
-<script src="/static/app.js?v=47"></script>
+<script src="/static/app.js?v=48"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds a fourth way out of the scan crop dialog, for the case where the photo itself was the problem.

**Retake replaces Cancel.** Buttons stay three wide: Retake, Full photo, Use crop. Esc and the backdrop still abandon the scan outright, which is what Cancel did, so nothing is lost. A fourth button wrapped to two rows on a phone.

**The reopen has to be synchronous.** `scanCrop()` now takes the input that produced the photo and clicks it from inside the Retake handler itself, before resolving. A file input opened from a promise continuation can be refused by a mobile browser as a non-gesture. The input's `value` is cleared first, otherwise re-picking an identical file never fires `change`.

**The no-crop path now shows the dialog too.** It used to return the photo silently whenever the server found no document, which is exactly the case a bad photo lands in, so the retake button would have been missing where it was needed most. That path shows the photo on its own with Retake and Attach as taken.

Nothing to crop is not a failure though. A car part, a paint defect or crash damage is a whole photo by design, so Attach as taken stays the main action there rather than being framed as a fallback.

`scanCrop()` resolves a `SCAN_RETAKE` sentinel so each of the three call sites can react. Only the add entry dialog needs to: it holds the scan in a local until save, so a retake nulls it rather than letting the discarded photo ride along.

No server change. v1.12.0, cache bust to `?v=48`.

### Testing

Needs a phone for the parts that matter, the user activation question does not reproduce on desktop.

- Crop found, Retake reopens the camera, dialog reappears on the new photo
- No document in frame, dialog still appears, single figure, no Use crop
- Re-pick the identical file after Retake, dialog reappears
- Add entry: scan, Retake, scan a different receipt, save, exactly one attachment and it is the second
- Esc still abandons and clears the field
