### PR TITLE
Separate scanning a document from taking a photo (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,9 @@ cost per year, per km, and what's due next?*
   change would move a service or belt due date, showing the old date and the new
   one, because a date or an odometer correction can quietly shift a clock.
 - Document attachments: hang receipts, invoices, certs and test reports (PDF or
-  photos, 10 MB each) on any entry via the 📎 on its row, or in the car's
-  Documents section for paperwork with no cost attached. A plain file picker
-  sits alongside for PDFs and existing photos, which are stored exactly as
-  received.
+  photos, 10 MB each) on any entry via the 📎 on its row, or in the car's Docs
+  and pics card for anything with no cost attached. A plain file picker sits
+  alongside for PDFs and existing photos, which are stored exactly as received.
 - Scan a receipt and it comes out flat. Scanning opens the camera directly, the
   server finds the document in the photo and flattens it, and you see the crop
   beside the photo as taken and choose which to keep. Nothing is stored until
@@ -74,10 +73,15 @@ cost per year, per km, and what's due next?*
   in the browser precisely so that it does not depend on what phone you happen
   to be holding, and an instance without the optional scanning dependency simply
   attaches what you took.
-- Scan and Pic are separate buttons. Scan is for paperwork and runs the crop
-  step above. Pic is the same camera with none of it, for a wheel, a paint
-  defect or crash damage, which are whole photos with no document in them to
-  find. Both sit beside the plain file picker everywhere an attachment can go.
+- Scan and Pic are separate buttons in the Docs and pics card. Scan is for
+  paperwork and runs the crop step above. Pic is the same camera with none of
+  it, for a wheel, a paint defect or crash damage, which are whole photos with
+  no document in them to find. An expense only offers Scan, because what belongs
+  on a fuel or toll entry is its receipt.
+- Tick "Keep camera open for more" and the camera comes straight back after each
+  one, so a set of damage photos or a receipt that runs to several pages is one
+  trip rather than several. Each lands as it is taken and the list catches up
+  when you untick.
 
 **A status page per car**
 - Tap-to-upload photo (resized server-side, shown in a consistent 4:3 frame

--- a/README.md
+++ b/README.md
@@ -69,10 +69,15 @@ cost per year, per km, and what's due next?*
   beside the photo as taken and choose which to keep. Nothing is stored until
   you pick, so a detection that gets it wrong costs you a tap. If the photo
   itself did not come out, Retake reopens the camera on the spot rather than
-  making you start the scan again. If no document is found, or the optional
-  scanning dependency is not installed, you are offered the photo as taken or
-  another go at it. Detection runs on the server rather than in the browser
-  precisely so that it does not depend on what phone you happen to be holding.
+  making you start the scan again. If no document is found you are offered the
+  photo as taken or another go at it. Detection runs on the server rather than
+  in the browser precisely so that it does not depend on what phone you happen
+  to be holding, and an instance without the optional scanning dependency simply
+  attaches what you took.
+- Scan and Pic are separate buttons. Scan is for paperwork and runs the crop
+  step above. Pic is the same camera with none of it, for a wheel, a paint
+  defect or crash damage, which are whole photos with no document in them to
+  find. Both sit beside the plain file picker everywhere an attachment can go.
 
 **A status page per car**
 - Tap-to-upload photo (resized server-side, shown in a consistent 4:3 frame

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ cost per year, per km, and what's due next?*
 - Scan a receipt and it comes out flat. Scanning opens the camera directly, the
   server finds the document in the photo and flattens it, and you see the crop
   beside the photo as taken and choose which to keep. Nothing is stored until
-  you pick, so a detection that gets it wrong costs you a tap. If no document is
-  found, or the optional scanning dependency is not installed, the photo simply
-  attaches as taken. Detection runs on the server rather than in the browser
+  you pick, so a detection that gets it wrong costs you a tap. If the photo
+  itself did not come out, Retake reopens the camera on the spot rather than
+  making you start the scan again. If no document is found, or the optional
+  scanning dependency is not installed, you are offered the photo as taken or
+  another go at it. Detection runs on the server rather than in the browser
   precisely so that it does not depend on what phone you happen to be holding.
 
 **A status page per car**

--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ cost per year, per km, and what's due next?*
   it, for a wheel, a paint defect or crash damage, which are whole photos with
   no document in them to find. An expense only offers Scan, because what belongs
   on a fuel or toll entry is its receipt.
-- Tick "Keep camera open for more" and the camera comes straight back after each
-  one, so a set of damage photos or a receipt that runs to several pages is one
-  trip rather than several. Each lands as it is taken and the list catches up
-  when you untick.
+- Every scan and pic offers Take another, so a set of damage photos or a receipt
+  running to several pages is one trip rather than several. Each lands as it is
+  taken and the list catches up when you are done. It is a button rather than
+  something you set beforehand because a phone only reopens the camera from a
+  real tap.
 
 **A status page per car**
 - Tap-to-upload photo (resized server-side, shown in a consistent 4:3 frame

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ TYRE_CORNERS = ("FL", "FR", "RL", "RR")
 BASELINE_NOTE = "Full tread when fitted"   # marks the check a tyre fitting writes for itself
 FUEL_TYPES = ("petrol", "diesel", "hybrid", "phev", "ev")
 
-APP_VERSION = "1.12.0"   # bump on release; shown on the home screen
+APP_VERSION = "1.13.0"   # bump on release; shown on the home screen
 
 app = FastAPI(title="Car Costs", version=APP_VERSION)
 

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ TYRE_CORNERS = ("FL", "FR", "RL", "RR")
 BASELINE_NOTE = "Full tread when fitted"   # marks the check a tyre fitting writes for itself
 FUEL_TYPES = ("petrol", "diesel", "hybrid", "phev", "ev")
 
-APP_VERSION = "1.11.0"   # bump on release; shown on the home screen
+APP_VERSION = "1.12.0"   # bump on release; shown on the home screen
 
 app = FastAPI(title="Car Costs", version=APP_VERSION)
 

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ TYRE_CORNERS = ("FL", "FR", "RL", "RR")
 BASELINE_NOTE = "Full tread when fitted"   # marks the check a tyre fitting writes for itself
 FUEL_TYPES = ("petrol", "diesel", "hybrid", "phev", "ev")
 
-APP_VERSION = "1.14.0"   # bump on release; shown on the home screen
+APP_VERSION = "1.14.1"   # bump on release; shown on the home screen
 
 app = FastAPI(title="Car Costs", version=APP_VERSION)
 

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ TYRE_CORNERS = ("FL", "FR", "RL", "RR")
 BASELINE_NOTE = "Full tread when fitted"   # marks the check a tyre fitting writes for itself
 FUEL_TYPES = ("petrol", "diesel", "hybrid", "phev", "ev")
 
-APP_VERSION = "1.13.0"   # bump on release; shown on the home screen
+APP_VERSION = "1.14.0"   # bump on release; shown on the home screen
 
 app = FastAPI(title="Car Costs", version=APP_VERSION)
 

--- a/static/app.js
+++ b/static/app.js
@@ -294,8 +294,6 @@ async function showCar(id, year) {
         <button class="ghost" id="photo-doc" style="flex:1">📷 Pic</button>
         <button class="ghost" id="scan-doc" style="flex:1">📄 Scan</button>
         <button class="ghost" id="add-doc" style="flex:1">📁 File</button></div>
-      <label class="switch" style="margin-top:10px"><input type="checkbox" id="doc-again">
-        Keep camera open for more</label>
       <input type="file" id="doc-scan" accept="image/*" capture="environment" hidden>
       <input type="file" id="doc-photo" accept="image/*" capture="environment" hidden>
       <input type="file" id="doc-file" accept="image/*,application/pdf" hidden>
@@ -356,10 +354,12 @@ async function showCar(id, year) {
   $("#photo-doc").addEventListener("click", () => $("#doc-photo").click());
   $("#add-doc").addEventListener("click", () => $("#doc-file").click());
 
-  // A batch keeps the camera coming back. Uploads are chained rather than fired
-  // in parallel, and rows are appended as they land: a full re-render mid-batch
-  // would destroy the very input the camera is attached to.
-  const more = () => $("#doc-again").checked;
+  // Several in a row: each camera attachment offers another go. The reopen has
+  // to happen inside a real tap, which is why this is a button and not something
+  // you set beforehand — a `change` event grants no user activation on a phone,
+  // so a camera opened from one is silently refused. Uploads are chained rather
+  // than fired in parallel, and rows are appended as they land: a full re-render
+  // mid-run would destroy the very input the camera is attached to.
   let queue = Promise.resolve(), shot = 0;
   const addRow = att => {
     const empty = $("#doc-empty");
@@ -374,9 +374,22 @@ async function showCar(id, year) {
     });
     $("#doc-list").append(row);
   };
-  // Leaving the batch is the moment to catch up with the server properly.
-  $("#doc-again").addEventListener("change", ev => {
-    if (!ev.target.checked) queue.then(() => showCar(id));
+  // Asked while the upload runs, so the camera comes back without waiting on it.
+  const askAnother = (el, what) => new Promise(resolve => {
+    const dlg = document.createElement("dialog");
+    dlg.innerHTML = `<h1>${what} attached</h1>
+      <p class="hint" style="margin:0">Take another, or you are done.</p>
+      <div class="dlg-actions"><button type="button" class="ghost" id="ta-done">Done</button>
+      <button type="button" id="ta-more">Take another</button></div>`;
+    document.body.append(dlg);
+    const end = more => { dlg.close(); dlg.remove(); resolve(more); };
+    $("#ta-more", dlg).addEventListener("click", () => {
+      el.value = ""; el.click();   // inside the tap, which is the whole point
+      end(true);
+    });
+    $("#ta-done", dlg).addEventListener("click", () => end(false));
+    dlg.addEventListener("cancel", ev => { ev.preventDefault(); end(false); });
+    dlg.showModal();
   });
 
   for (const inp of ["#doc-scan", "#doc-photo", "#doc-file"])
@@ -385,22 +398,21 @@ async function showCar(id, year) {
       if (!file) return;
       let doc = file;
       if (inp === "#doc-scan") {
-        doc = await scanCrop(file, el, more);   // reopens itself on accept if `more`
-        if (doc === SCAN_RETAKE) return;
+        doc = await scanCrop(file, el);
+        if (doc === SCAN_RETAKE) return;   // scanCrop already reopened the camera
         if (!doc) { el.value = ""; return; }
-      } else if (inp === "#doc-photo" && more()) {
-        // Reopen before uploading, not after: the click has to ride this change
-        // event's user gesture and an await would have spent it.
-        el.value = ""; el.click();
       }
-      const batched = inp !== "#doc-file" && more();
-      const name = doc === file ? undefined : (batched ? `scan-${++shot}.jpg` : "scan.jpg");
-      queue = queue.then(async () => {
-        try {
-          const att = await uploadDoc(`/api/cars/${id}/attachments`, doc, name);
-          if (batched) addRow(att); else showCar(id);
-        } catch (e) { alert(e.message); }
+      // Scans share one name, so a second in a row would collide.
+      const name = doc === file ? undefined : (++shot > 1 ? `scan-${shot}.jpg` : "scan.jpg");
+      const upload = queue = queue.then(async () => {
+        try { return await uploadDoc(`/api/cars/${id}/attachments`, doc, name); }
+        catch (e) { alert(e.message); }
       });
+      if (inp === "#doc-file") { await upload; showCar(id); return; }
+      const more = await askAnother(el, inp === "#doc-scan" ? "Scan" : "Photo");
+      const att = await upload;
+      if (!more) showCar(id);
+      else if (att) addRow(att);
     });
 }
 
@@ -425,9 +437,7 @@ async function uploadDoc(path, file, name) {
    not a failure though — a car part, a paint defect or crash damage is a whole
    photo by design, so that path keeps "Attach as taken" as the main action. */
 const SCAN_RETAKE = Symbol("retake");
-// `more` is an optional predicate: true at accept time means reopen the camera
-// for another, which only the Docs and pics card asks for.
-async function scanCrop(file, input, more) {
+async function scanCrop(file, input) {
   let crop = null;
   try {
     const fd = new FormData();
@@ -468,14 +478,8 @@ async function scanCrop(file, input, more) {
       if (input) { input.value = ""; input.click(); }
       finish(SCAN_RETAKE);
     });
-    // Accepting inside a batch reopens the camera on the same terms as Retake:
-    // inside the click, value cleared first, nothing awaited in between.
-    const accept = val => {
-      if (more && more() && input) { input.value = ""; input.click(); }
-      finish(val);
-    };
-    $("#sc-full", dlg).addEventListener("click", () => accept(file));
-    if (crop) $("#sc-crop", dlg).addEventListener("click", () => accept(crop));
+    $("#sc-full", dlg).addEventListener("click", () => finish(file));
+    if (crop) $("#sc-crop", dlg).addEventListener("click", () => finish(crop));
     dlg.addEventListener("cancel", ev => { ev.preventDefault(); finish(null); });   // Esc abandons the scan
     dlg.showModal();
   });

--- a/static/app.js
+++ b/static/app.js
@@ -289,11 +289,13 @@ async function showCar(id, year) {
       ${(d.attachments || []).map(a => `
         <div class="entry"><span class="doc-open" data-open="${a.id}">${esc(a.filename)} <span class="muted">${dmy(a.created)}</span></span>
         <button class="danger" data-adel="${a.id}">✕</button></div>`).join("") ||
-        '<div class="muted">No documents yet — certs, receipts and reports live here.</div>'}
+        '<div class="muted">No documents yet — certs, receipts and reports live here, and so do photos of the car.</div>'}
       <div class="row" style="gap:10px;margin-top:8px">
-        <button class="ghost" id="scan-doc" style="flex:1">📷 Scan…</button>
-        <button class="ghost" id="add-doc" style="flex:1">+ Attach file…</button></div>
+        <button class="ghost" id="scan-doc" style="flex:1">📄 Scan</button>
+        <button class="ghost" id="photo-doc" style="flex:1">📷 Pic</button>
+        <button class="ghost" id="add-doc" style="flex:1">+ File</button></div>
       <input type="file" id="doc-scan" accept="image/*" capture="environment" hidden>
+      <input type="file" id="doc-photo" accept="image/*" capture="environment" hidden>
       <input type="file" id="doc-file" accept="image/*,application/pdf" hidden>
     </div>`;
   c._entries = d.entries;   // an edit needs its tyre fitting's companion baseline check
@@ -345,9 +347,12 @@ async function showCar(id, year) {
     b.addEventListener("click", async () => {
       if (confirm("Delete this document?")) { await api(`/api/attachments/${b.dataset.adel}`, { method: "DELETE" }); showCar(id); }
     }));
+  // Scan runs the crop step; Photo is the same camera with none of it, because a
+  // wheel or a paint defect is a whole photo and has no document to find in it.
   $("#scan-doc").addEventListener("click", () => $("#doc-scan").click());
+  $("#photo-doc").addEventListener("click", () => $("#doc-photo").click());
   $("#add-doc").addEventListener("click", () => $("#doc-file").click());
-  for (const inp of ["#doc-scan", "#doc-file"])
+  for (const inp of ["#doc-scan", "#doc-photo", "#doc-file"])
     $(inp).addEventListener("change", async ev => {
       const file = ev.target.files[0];
       if (!file) return;
@@ -388,13 +393,16 @@ async function scanCrop(file, input) {
     const r = await fetch("/api/scan/preview", { method: "POST", body: fd });
     if (!r.ok) return file;
     if ((r.headers.get("content-type") || "").startsWith("image/")) crop = await r.blob();
+    // Only "no document found" is worth asking about. An instance without the
+    // scanning dependency would otherwise pop this dialog on every single scan.
+    else if ((await r.json()).reason !== "no document found") return file;
   } catch (e) { return file; }
 
   const cropUrl = crop ? URL.createObjectURL(crop) : null, fullUrl = URL.createObjectURL(file);
   return new Promise(resolve => {
     const dlg = document.createElement("dialog");
     dlg.className = "scan-dlg";
-    dlg.innerHTML = `<h1>Crop scan</h1>
+    dlg.innerHTML = `<h1>${crop ? "Crop scan" : "Scan"}</h1>
       <p class="hint" style="margin:0 0 8px">${crop
         ? "Cropped to the document. Keep it, or attach the photo as taken."
         : "Nothing to crop here, so the whole photo goes up. Take it again if it did not come out."}</p>
@@ -403,7 +411,7 @@ async function scanCrop(file, input) {
         <figure><img src="${fullUrl}" alt="Photo as taken"><figcaption>As taken</figcaption></figure>
       </div>
       <div class="dlg-actions"><button type="button" class="ghost" id="sc-retake">Retake</button>
-      <button type="button" class="ghost" id="sc-full">${crop ? "Full photo" : "Attach as taken"}</button>
+      <button type="button" ${crop ? `class="ghost"` : ""} id="sc-full">${crop ? "Full photo" : "Attach as taken"}</button>
       ${crop ? `<button type="button" id="sc-crop">Use crop</button>` : ""}</div>`;
     document.body.append(dlg);
     const finish = val => {
@@ -537,8 +545,10 @@ function attachmentsDialog(car, entry) {
       <button type="button" class="danger" data-adel="${a.id}">✕</button></div>`).join("") ||
       '<div class="muted">Nothing attached yet.</div>'}
     <input type="file" class="att-scan" accept="image/*" capture="environment" hidden>
+    <input type="file" class="att-photo" accept="image/*" capture="environment" hidden>
     <input type="file" class="att-file" accept="image/*,application/pdf" hidden>
-    <div class="dlg-actions"><button type="button" id="att-scan">📷 Scan…</button>
+    <div class="dlg-actions"><button type="button" id="att-scan">📄 Scan doc</button>
+    <button type="button" class="ghost" id="att-photo">📷 Photo</button>
     <button type="button" class="ghost" id="att-add">Attach file…</button>
     <button class="ghost" value="cancel" formnovalidate>Close</button></div></form>`;
   document.body.append(dlg);
@@ -553,6 +563,7 @@ function attachmentsDialog(car, entry) {
       dlg.close("cancel"); showCar(car.id);
     }));
   $("#att-scan", dlg).addEventListener("click", () => $(".att-scan", dlg).click());
+  $("#att-photo", dlg).addEventListener("click", () => $(".att-photo", dlg).click());
   $("#att-add", dlg).addEventListener("click", () => $(".att-file", dlg).click());
   dlg.querySelectorAll("input[type=file]").forEach(inp =>
     inp.addEventListener("change", async ev => {
@@ -741,7 +752,8 @@ function prefillEntry(dlg, cat, entry, car) {
     el.remove();
   };
   // A scan belongs to the 📎 dialog, and a renewal date belongs to the car, not the entry.
-  drop("doc");
+  const picker = dlg.querySelector("#doc-pick");   // label, both cameras and the status line
+  if (picker) picker.remove();
   drop("due");
   if (PERIODIC.includes(cat)) {
     // The type has to change before the value: a month string assigned to a
@@ -848,8 +860,16 @@ function entryDialog(car, cat, entry) {
        <label>Note</label><input name="note" placeholder="optional">`;
   let scanBlob = null;
   const docField = cat === "odo" ? "" : `
-      <label>Scan receipt / report (optional)</label>
-      <input name="doc" type="file" accept="image/*" capture="environment">`;
+      <div id="doc-pick">
+        <label>Receipt, report or photo (optional)</label>
+        <div class="row" style="gap:10px">
+          <button type="button" class="ghost" id="ent-scan" style="flex:1">📄 Scan doc</button>
+          <button type="button" class="ghost" id="ent-photo" style="flex:1">📷 Photo</button>
+        </div>
+        <div class="hint" id="ent-doc-status"></div>
+        <input type="file" class="ent-scan" accept="image/*" capture="environment" hidden>
+        <input type="file" class="ent-photo" accept="image/*" capture="environment" hidden>
+      </div>`;
   const dlg = dialog(`
     <h1>${entry ? "Edit" : CAT_LABELS[cat]} — ${entry ? CAT_LABELS[cat] : esc(car.name)}</h1>
     <label>Date</label><input name="date" type="date" value="${today()}" required>
@@ -919,16 +939,29 @@ function entryDialog(car, cat, entry) {
       dateInput.value = monthly ? today().slice(0, 7) : today();
     }));
   }
-  const docInput = $("input[name=doc]", dlg);
-  if (docInput) docInput.addEventListener("change", async ev => {
-    const file = ev.target.files[0];
-    if (!file) { scanBlob = null; return; }
-    const doc = await scanCrop(file, ev.target);
-    // A retake replaces the held photo rather than adding a second one.
-    if (doc === SCAN_RETAKE) { scanBlob = null; return; }
-    scanBlob = doc;
-    if (!scanBlob) ev.target.value = "";
-  });
+  // Two cameras, one held blob. Scan crops, Photo attaches what it took: a
+  // damage photo on a repair has no document in it to find.
+  const status = $("#ent-doc-status", dlg);
+  const setStatus = () => {
+    status.textContent = !scanBlob ? ""
+      : scanBlob instanceof File ? `Attached: ${scanBlob.name}` : "Cropped scan attached";
+  };
+  if (status) {
+    $("#ent-scan", dlg).addEventListener("click", () => $(".ent-scan", dlg).click());
+    $("#ent-photo", dlg).addEventListener("click", () => $(".ent-photo", dlg).click());
+    dlg.querySelectorAll(".ent-scan, .ent-photo").forEach(inp =>
+      inp.addEventListener("change", async ev => {
+        const file = ev.target.files[0];
+        if (!file) { scanBlob = null; setStatus(); return; }
+        if (inp.classList.contains("ent-photo")) { scanBlob = file; setStatus(); return; }
+        const doc = await scanCrop(file, ev.target);
+        // A retake replaces the held photo rather than adding a second one.
+        if (doc === SCAN_RETAKE) { scanBlob = null; setStatus(); return; }
+        scanBlob = doc;
+        if (!scanBlob) ev.target.value = "";
+        setStatus();
+      }));
+  }
   if (isFuel || isCharge) {
     const upd = () => {
       const f = new FormData($("form", dlg));

--- a/static/app.js
+++ b/static/app.js
@@ -351,7 +351,8 @@ async function showCar(id, year) {
     $(inp).addEventListener("change", async ev => {
       const file = ev.target.files[0];
       if (!file) return;
-      const doc = inp === "#doc-scan" ? await scanCrop(file) : file;
+      const doc = inp === "#doc-scan" ? await scanCrop(file, ev.target) : file;
+      if (doc === SCAN_RETAKE) return;   // scanCrop already reopened the camera
       if (!doc) { ev.target.value = ""; return; }
       try { await uploadDoc(`/api/cars/${id}/attachments`, doc, doc === file ? undefined : "scan.jpg"); showCar(id); }
       catch (e) { alert(e.message); }
@@ -370,9 +371,16 @@ async function uploadDoc(path, file, name) {
    the browser with a 9 MB OpenCV build and never once worked on a phone, which
    is the whole reason it moved. Picker-chosen files skip all of this.
 
-   Returns a cropped JPEG Blob, the original file, or null (cancelled). Anything
-   that goes wrong returns the original — a scan is never lost to this step. */
-async function scanCrop(file) {
+   Returns a cropped JPEG Blob, the original file, SCAN_RETAKE (#36, take the
+   photo again) or null (cancelled). Anything that goes wrong returns the
+   original — a scan is never lost to this step.
+
+   The dialog also opens when the server found nothing to crop, so that a bad
+   photo can be taken again instead of attaching silently. Nothing to crop is
+   not a failure though — a car part, a paint defect or crash damage is a whole
+   photo by design, so that path keeps "Attach as taken" as the main action. */
+const SCAN_RETAKE = Symbol("retake");
+async function scanCrop(file, input) {
   let crop = null;
   try {
     const fd = new FormData();
@@ -381,30 +389,38 @@ async function scanCrop(file) {
     if (!r.ok) return file;
     if ((r.headers.get("content-type") || "").startsWith("image/")) crop = await r.blob();
   } catch (e) { return file; }
-  if (!crop) return file;          // no document found, or the server has no scanner
 
-  const cropUrl = URL.createObjectURL(crop), fullUrl = URL.createObjectURL(file);
+  const cropUrl = crop ? URL.createObjectURL(crop) : null, fullUrl = URL.createObjectURL(file);
   return new Promise(resolve => {
     const dlg = document.createElement("dialog");
     dlg.className = "scan-dlg";
     dlg.innerHTML = `<h1>Crop scan</h1>
-      <p class="hint" style="margin:0 0 8px">Cropped to the document. Keep it, or attach the photo as taken.</p>
+      <p class="hint" style="margin:0 0 8px">${crop
+        ? "Cropped to the document. Keep it, or attach the photo as taken."
+        : "Nothing to crop here, so the whole photo goes up. Take it again if it did not come out."}</p>
       <div class="scan-pair">
-        <figure><img src="${cropUrl}" alt="Cropped scan"><figcaption>Cropped</figcaption></figure>
+        ${crop ? `<figure><img src="${cropUrl}" alt="Cropped scan"><figcaption>Cropped</figcaption></figure>` : ""}
         <figure><img src="${fullUrl}" alt="Photo as taken"><figcaption>As taken</figcaption></figure>
       </div>
-      <div class="dlg-actions"><button type="button" class="ghost" id="sc-cancel">Cancel</button>
-      <button type="button" class="ghost" id="sc-full">Full photo</button>
-      <button type="button" id="sc-crop">Use crop</button></div>`;
+      <div class="dlg-actions"><button type="button" class="ghost" id="sc-retake">Retake</button>
+      <button type="button" class="ghost" id="sc-full">${crop ? "Full photo" : "Attach as taken"}</button>
+      ${crop ? `<button type="button" id="sc-crop">Use crop</button>` : ""}</div>`;
     document.body.append(dlg);
     const finish = val => {
-      URL.revokeObjectURL(cropUrl); URL.revokeObjectURL(fullUrl);
+      if (cropUrl) URL.revokeObjectURL(cropUrl);
+      URL.revokeObjectURL(fullUrl);
       dlg.close(); dlg.remove(); resolve(val);
     };
-    $("#sc-cancel", dlg).addEventListener("click", () => finish(null));
+    $("#sc-retake", dlg).addEventListener("click", () => {
+      // Reopen from inside the click itself — a mobile browser refuses a file
+      // input opened any later. Clearing the value first is what lets the same
+      // photo fire `change` a second time.
+      if (input) { input.value = ""; input.click(); }
+      finish(SCAN_RETAKE);
+    });
     $("#sc-full", dlg).addEventListener("click", () => finish(file));
-    $("#sc-crop", dlg).addEventListener("click", () => finish(crop));
-    dlg.addEventListener("cancel", ev => { ev.preventDefault(); finish(null); });
+    if (crop) $("#sc-crop", dlg).addEventListener("click", () => finish(crop));
+    dlg.addEventListener("cancel", ev => { ev.preventDefault(); finish(null); });   // Esc abandons the scan
     dlg.showModal();
   });
 }
@@ -542,7 +558,8 @@ function attachmentsDialog(car, entry) {
     inp.addEventListener("change", async ev => {
       const file = ev.target.files[0];
       if (!file) return;
-      const doc = inp.classList.contains("att-scan") ? await scanCrop(file) : file;
+      const doc = inp.classList.contains("att-scan") ? await scanCrop(file, ev.target) : file;
+      if (doc === SCAN_RETAKE) return;   // scanCrop already reopened the camera
       if (!doc) { ev.target.value = ""; return; }
       try { await uploadDoc(`/api/entries/${entry.id}/attachments`, doc, doc === file ? undefined : "scan.jpg"); }
       catch (e) { alert(e.message); return; }
@@ -906,7 +923,10 @@ function entryDialog(car, cat, entry) {
   if (docInput) docInput.addEventListener("change", async ev => {
     const file = ev.target.files[0];
     if (!file) { scanBlob = null; return; }
-    scanBlob = await scanCrop(file);
+    const doc = await scanCrop(file, ev.target);
+    // A retake replaces the held photo rather than adding a second one.
+    if (doc === SCAN_RETAKE) { scanBlob = null; return; }
+    scanBlob = doc;
     if (!scanBlob) ev.target.value = "";
   });
   if (isFuel || isCharge) {

--- a/static/app.js
+++ b/static/app.js
@@ -285,15 +285,17 @@ async function showCar(id, year) {
         <span>${eur(s.cost)}</span></div>`).join("")}
       </div>
     </div>` : ""}
-    <div class="card"><div class="muted" style="margin-bottom:4px">Documents</div>
-      ${(d.attachments || []).map(a => `
+    <div class="card"><div class="muted" style="margin-bottom:4px">Docs and pics</div>
+      <div id="doc-list">${(d.attachments || []).map(a => `
         <div class="entry"><span class="doc-open" data-open="${a.id}">${esc(a.filename)} <span class="muted">${dmy(a.created)}</span></span>
         <button class="danger" data-adel="${a.id}">✕</button></div>`).join("") ||
-        '<div class="muted">No documents yet — certs, receipts and reports live here, and so do photos of the car.</div>'}
+        '<div class="muted" id="doc-empty">Nothing here yet — certs, receipts and reports live here, and so do pictures of the car.</div>'}</div>
       <div class="row" style="gap:10px;margin-top:8px">
-        <button class="ghost" id="scan-doc" style="flex:1">📄 Scan</button>
         <button class="ghost" id="photo-doc" style="flex:1">📷 Pic</button>
-        <button class="ghost" id="add-doc" style="flex:1">+ File</button></div>
+        <button class="ghost" id="scan-doc" style="flex:1">📄 Scan</button>
+        <button class="ghost" id="add-doc" style="flex:1">📁 File</button></div>
+      <label class="switch" style="margin-top:10px"><input type="checkbox" id="doc-again">
+        Keep camera open for more</label>
       <input type="file" id="doc-scan" accept="image/*" capture="environment" hidden>
       <input type="file" id="doc-photo" accept="image/*" capture="environment" hidden>
       <input type="file" id="doc-file" accept="image/*,application/pdf" hidden>
@@ -347,20 +349,58 @@ async function showCar(id, year) {
     b.addEventListener("click", async () => {
       if (confirm("Delete this document?")) { await api(`/api/attachments/${b.dataset.adel}`, { method: "DELETE" }); showCar(id); }
     }));
-  // Scan runs the crop step; Photo is the same camera with none of it, because a
-  // wheel or a paint defect is a whole photo and has no document to find in it.
+  // Scan runs the crop step. Pic is the same camera with none of it, because a
+  // wheel or a paint defect is a whole photo with no document in it to find, and
+  // it only lives here: an expense wants a receipt, not a picture of the car.
   $("#scan-doc").addEventListener("click", () => $("#doc-scan").click());
   $("#photo-doc").addEventListener("click", () => $("#doc-photo").click());
   $("#add-doc").addEventListener("click", () => $("#doc-file").click());
+
+  // A batch keeps the camera coming back. Uploads are chained rather than fired
+  // in parallel, and rows are appended as they land: a full re-render mid-batch
+  // would destroy the very input the camera is attached to.
+  const more = () => $("#doc-again").checked;
+  let queue = Promise.resolve(), shot = 0;
+  const addRow = att => {
+    const empty = $("#doc-empty");
+    if (empty) empty.remove();
+    const row = document.createElement("div");
+    row.className = "entry";
+    row.innerHTML = `<span class="doc-open" data-open="${att.id}">${esc(att.filename)} <span class="muted">${dmy(att.created)}</span></span>
+      <button class="danger" data-adel="${att.id}">✕</button>`;
+    $("[data-open]", row).addEventListener("click", () => window.open(`/api/attachments/${att.id}`));
+    $("[data-adel]", row).addEventListener("click", async () => {
+      if (confirm("Delete this document?")) { await api(`/api/attachments/${att.id}`, { method: "DELETE" }); showCar(id); }
+    });
+    $("#doc-list").append(row);
+  };
+  // Leaving the batch is the moment to catch up with the server properly.
+  $("#doc-again").addEventListener("change", ev => {
+    if (!ev.target.checked) queue.then(() => showCar(id));
+  });
+
   for (const inp of ["#doc-scan", "#doc-photo", "#doc-file"])
     $(inp).addEventListener("change", async ev => {
-      const file = ev.target.files[0];
+      const el = ev.target, file = el.files[0];
       if (!file) return;
-      const doc = inp === "#doc-scan" ? await scanCrop(file, ev.target) : file;
-      if (doc === SCAN_RETAKE) return;   // scanCrop already reopened the camera
-      if (!doc) { ev.target.value = ""; return; }
-      try { await uploadDoc(`/api/cars/${id}/attachments`, doc, doc === file ? undefined : "scan.jpg"); showCar(id); }
-      catch (e) { alert(e.message); }
+      let doc = file;
+      if (inp === "#doc-scan") {
+        doc = await scanCrop(file, el, more);   // reopens itself on accept if `more`
+        if (doc === SCAN_RETAKE) return;
+        if (!doc) { el.value = ""; return; }
+      } else if (inp === "#doc-photo" && more()) {
+        // Reopen before uploading, not after: the click has to ride this change
+        // event's user gesture and an await would have spent it.
+        el.value = ""; el.click();
+      }
+      const batched = inp !== "#doc-file" && more();
+      const name = doc === file ? undefined : (batched ? `scan-${++shot}.jpg` : "scan.jpg");
+      queue = queue.then(async () => {
+        try {
+          const att = await uploadDoc(`/api/cars/${id}/attachments`, doc, name);
+          if (batched) addRow(att); else showCar(id);
+        } catch (e) { alert(e.message); }
+      });
     });
 }
 
@@ -385,7 +425,9 @@ async function uploadDoc(path, file, name) {
    not a failure though — a car part, a paint defect or crash damage is a whole
    photo by design, so that path keeps "Attach as taken" as the main action. */
 const SCAN_RETAKE = Symbol("retake");
-async function scanCrop(file, input) {
+// `more` is an optional predicate: true at accept time means reopen the camera
+// for another, which only the Docs and pics card asks for.
+async function scanCrop(file, input, more) {
   let crop = null;
   try {
     const fd = new FormData();
@@ -426,8 +468,14 @@ async function scanCrop(file, input) {
       if (input) { input.value = ""; input.click(); }
       finish(SCAN_RETAKE);
     });
-    $("#sc-full", dlg).addEventListener("click", () => finish(file));
-    if (crop) $("#sc-crop", dlg).addEventListener("click", () => finish(crop));
+    // Accepting inside a batch reopens the camera on the same terms as Retake:
+    // inside the click, value cleared first, nothing awaited in between.
+    const accept = val => {
+      if (more && more() && input) { input.value = ""; input.click(); }
+      finish(val);
+    };
+    $("#sc-full", dlg).addEventListener("click", () => accept(file));
+    if (crop) $("#sc-crop", dlg).addEventListener("click", () => accept(crop));
     dlg.addEventListener("cancel", ev => { ev.preventDefault(); finish(null); });   // Esc abandons the scan
     dlg.showModal();
   });
@@ -545,10 +593,8 @@ function attachmentsDialog(car, entry) {
       <button type="button" class="danger" data-adel="${a.id}">✕</button></div>`).join("") ||
       '<div class="muted">Nothing attached yet.</div>'}
     <input type="file" class="att-scan" accept="image/*" capture="environment" hidden>
-    <input type="file" class="att-photo" accept="image/*" capture="environment" hidden>
     <input type="file" class="att-file" accept="image/*,application/pdf" hidden>
-    <div class="dlg-actions"><button type="button" id="att-scan">📄 Scan doc</button>
-    <button type="button" class="ghost" id="att-photo">📷 Photo</button>
+    <div class="dlg-actions"><button type="button" id="att-scan">📄 Scan</button>
     <button type="button" class="ghost" id="att-add">Attach file…</button>
     <button class="ghost" value="cancel" formnovalidate>Close</button></div></form>`;
   document.body.append(dlg);
@@ -563,7 +609,6 @@ function attachmentsDialog(car, entry) {
       dlg.close("cancel"); showCar(car.id);
     }));
   $("#att-scan", dlg).addEventListener("click", () => $(".att-scan", dlg).click());
-  $("#att-photo", dlg).addEventListener("click", () => $(".att-photo", dlg).click());
   $("#att-add", dlg).addEventListener("click", () => $(".att-file", dlg).click());
   dlg.querySelectorAll("input[type=file]").forEach(inp =>
     inp.addEventListener("change", async ev => {
@@ -861,14 +906,10 @@ function entryDialog(car, cat, entry) {
   let scanBlob = null;
   const docField = cat === "odo" ? "" : `
       <div id="doc-pick">
-        <label>Receipt, report or photo (optional)</label>
-        <div class="row" style="gap:10px">
-          <button type="button" class="ghost" id="ent-scan" style="flex:1">📄 Scan doc</button>
-          <button type="button" class="ghost" id="ent-photo" style="flex:1">📷 Photo</button>
-        </div>
+        <label>Scan receipt or report (optional)</label>
+        <button type="button" class="ghost" id="ent-scan" style="width:100%">📄 Scan</button>
         <div class="hint" id="ent-doc-status"></div>
         <input type="file" class="ent-scan" accept="image/*" capture="environment" hidden>
-        <input type="file" class="ent-photo" accept="image/*" capture="environment" hidden>
       </div>`;
   const dlg = dialog(`
     <h1>${entry ? "Edit" : CAT_LABELS[cat]} — ${entry ? CAT_LABELS[cat] : esc(car.name)}</h1>
@@ -939,28 +980,25 @@ function entryDialog(car, cat, entry) {
       dateInput.value = monthly ? today().slice(0, 7) : today();
     }));
   }
-  // Two cameras, one held blob. Scan crops, Photo attaches what it took: a
-  // damage photo on a repair has no document in it to find.
+  // An expense wants its receipt, so this is the scan path only. Pictures of the
+  // car itself belong in the car's own Docs and pics card.
   const status = $("#ent-doc-status", dlg);
-  const setStatus = () => {
-    status.textContent = !scanBlob ? ""
-      : scanBlob instanceof File ? `Attached: ${scanBlob.name}` : "Cropped scan attached";
-  };
   if (status) {
+    const setStatus = () => {
+      status.textContent = !scanBlob ? ""
+        : scanBlob instanceof File ? `Attached: ${scanBlob.name}` : "Cropped scan attached";
+    };
     $("#ent-scan", dlg).addEventListener("click", () => $(".ent-scan", dlg).click());
-    $("#ent-photo", dlg).addEventListener("click", () => $(".ent-photo", dlg).click());
-    dlg.querySelectorAll(".ent-scan, .ent-photo").forEach(inp =>
-      inp.addEventListener("change", async ev => {
-        const file = ev.target.files[0];
-        if (!file) { scanBlob = null; setStatus(); return; }
-        if (inp.classList.contains("ent-photo")) { scanBlob = file; setStatus(); return; }
-        const doc = await scanCrop(file, ev.target);
-        // A retake replaces the held photo rather than adding a second one.
-        if (doc === SCAN_RETAKE) { scanBlob = null; setStatus(); return; }
-        scanBlob = doc;
-        if (!scanBlob) ev.target.value = "";
-        setStatus();
-      }));
+    $(".ent-scan", dlg).addEventListener("change", async ev => {
+      const file = ev.target.files[0];
+      if (!file) { scanBlob = null; setStatus(); return; }
+      const doc = await scanCrop(file, ev.target);
+      // A retake replaces the held photo rather than adding a second one.
+      if (doc === SCAN_RETAKE) { scanBlob = null; setStatus(); return; }
+      scanBlob = doc;
+      if (!scanBlob) ev.target.value = "";
+      setStatus();
+    });
   }
   if (isFuel || isCharge) {
     const upd = () => {

--- a/static/index.html
+++ b/static/index.html
@@ -102,6 +102,6 @@ button.clip.clip-empty { opacity: .35; }
 </head>
 <body>
 <div id="app"></div>
-<script src="/static/app.js?v=47"></script>
+<script src="/static/app.js?v=48"></script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -102,6 +102,6 @@ button.clip.clip-empty { opacity: .35; }
 </head>
 <body>
 <div id="app"></div>
-<script src="/static/app.js?v=49"></script>
+<script src="/static/app.js?v=50"></script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -102,6 +102,6 @@ button.clip.clip-empty { opacity: .35; }
 </head>
 <body>
 <div id="app"></div>
-<script src="/static/app.js?v=48"></script>
+<script src="/static/app.js?v=49"></script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -102,6 +102,6 @@ button.clip.clip-empty { opacity: .35; }
 </head>
 <body>
 <div id="app"></div>
-<script src="/static/app.js?v=50"></script>
+<script src="/static/app.js?v=51"></script>
 </body>
 </html>


### PR DESCRIPTION
Splits the one camera button into two.

**Scan** keeps the crop step. **Pic** is the same camera with none of it: no server call, no crop dialog, no waiting. It attaches what you took, under the filename the camera gave it. Both sit beside the plain file picker in all three places an attachment can go.

The add entry dialog's visible "Scan receipt / report" file field becomes the same pair of buttons, with a line underneath saying what is held. On edit the whole picker is removed as before, since a scan belongs to the 📎 dialog.

### Also fixes a case from #36

An instance without the optional scanning dependency answers `{"cropped": false, "reason": "unavailable"}` rather than "no document found". Since the retake work stopped short circuiting on a missing crop, that meant the crop dialog appeared on every single scan for anyone self hosting without opencv. Only a real miss asks now. Not reachable on an instance that has the scanner, so it would not have shown up in normal use here.

### Stacking

Branched off `scan-retake`, not `main`, because #37 is not merged yet and both touch the same three call sites. Merge #37 first and this rebases cleanly.

### Testing

Driven in a real browser at 390 px, both with and without opencv installed, no page errors in any run.

- Pic makes no `/api/scan/preview` call and attaches directly, keeping its filename
- Scan does call it, and with a real document gets the three button crop dialog
- No document found gives the two button dialog, one image, heading "Scan", and Attach as taken as the primary rather than a ghost
- Retake closes the dialog, clears the input and uploads nothing
- Scanner absent attaches silently again, no dialog
- Add entry with a Pic saves one attachment with the right name; the status line reads it back
- Edit removes the picker entirely, no stray file inputs
- Attachments dialog on a row gets all three buttons and the photo path uploads

Still only provable on a phone: that Retake and the two camera buttons actually open the camera.

v1.13.0, cache bust to `?v=49`.
