### PR TITLE
Rotate a stored image attachment (#43)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1133,7 +1133,8 @@ def photo(name: str):
 # document has no cost entry to hang on (insurance cert after a date-only
 # renewal). Files are stored exactly as uploaded — no resizing, documents must
 # stay legible — under data/docs/, named by attachment id with an extension
-# derived from the sniffed type (never from the client's filename).
+# derived from the sniffed type (never from the client's filename). Rotating one
+# (issue #43) is the single exception, and it keeps the format and the name.
 DOC_EXT = {"application/pdf": "pdf", "image/jpeg": "jpg", "image/png": "png",
            "image/webp": "webp", "image/heic": "heic"}
 PIL_TYPES = {"JPEG": "image/jpeg", "PNG": "image/png", "WEBP": "image/webp", "HEIF": "image/heic"}
@@ -1377,6 +1378,57 @@ def get_attachment(att_id: int):
     safe = att["filename"].replace('"', "")
     return FileResponse(doc_path(att), media_type=att["media_type"],
                         headers={"Content-Disposition": f'inline; filename="{safe}"'})
+
+
+ROTATIONS = {90: Image.Transpose.ROTATE_270, 180: Image.Transpose.ROTATE_180,
+             270: Image.Transpose.ROTATE_90}   # clockwise degrees -> Pillow's anticlockwise names
+
+
+@app.post("/api/attachments/{att_id}/rotate")
+def rotate_attachment(att_id: int, degrees: int = 90):
+    """Turn a stored image clockwise and write it back (issue #43).
+
+    A photo taken over a receipt often lands sideways, and every other path here
+    is read-only, so the file would stay that way for good. This is the one place
+    the app rewrites an attachment; it keeps the format, the filename and the id,
+    because `doc_path()` is derived from the media type and the row must keep
+    pointing at its own file.
+
+    The transpose comes BEFORE the rotate: a phone JPEG carries its orientation
+    in EXIF, and the saved copy carries no EXIF at all, so anything that reads
+    the file afterwards sees the same picture the person just approved.
+    """
+    if degrees not in ROTATIONS:
+        raise HTTPException(422, "degrees must be 90, 180 or 270")
+    with db() as con:
+        att = con.execute("SELECT * FROM attachments WHERE id=?", (att_id,)).fetchone()
+    if not att or not os.path.isfile(doc_path(att)):
+        raise HTTPException(404, "no such attachment")
+    if att["media_type"] == "application/pdf":
+        raise HTTPException(422, "only images can be rotated")
+
+    path = doc_path(att)
+    tmp = os.path.join(DOCS_DIR, f".rotate-{pysecrets.token_hex(8)}")
+    try:
+        # Full resolution on purpose — _load_upright() drafts to a target size,
+        # which would quietly shrink the document every time it was turned.
+        with Image.open(path) as im:
+            fmt = im.format
+            out = ImageOps.exif_transpose(im).transpose(ROTATIONS[degrees])
+        opts = {"quality": 92} if fmt == "JPEG" else {}
+        out.save(tmp, format=fmt, **opts)
+        size = os.path.getsize(tmp)
+        os.replace(tmp, path)
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(422, "this image could not be rotated")
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+    with db() as con:
+        con.execute("UPDATE attachments SET size=? WHERE id=?", (size, att_id))
+        return dict(con.execute("SELECT * FROM attachments WHERE id=?", (att_id,)).fetchone())
 
 
 @app.delete("/api/attachments/{att_id}", status_code=204)

--- a/static/app.js
+++ b/static/app.js
@@ -288,7 +288,7 @@ async function showCar(id, year) {
     <div class="card"><div class="muted" style="margin-bottom:4px">Docs and pics</div>
       <div id="doc-list">${(d.attachments || []).map(a => `
         <div class="entry"><span class="doc-open" data-open="${a.id}">${esc(a.filename)} <span class="muted">${dmy(a.created)}</span></span>
-        <button class="danger" data-adel="${a.id}">✕</button></div>`).join("") ||
+        <span class="doc-btns">${rotBtn(a)}<button class="danger" data-adel="${a.id}">✕</button></span></div>`).join("") ||
         '<div class="muted" id="doc-empty">Nothing here yet — certs, receipts and reports live here, and so do pictures of the car.</div>'}</div>
       <div class="row" style="gap:10px;margin-top:8px">
         <button class="ghost" id="photo-doc" style="flex:1">📷 Pic</button>
@@ -342,11 +342,14 @@ async function showCar(id, year) {
       entryDetailDialog(c, d.entries.find(en => en.id === +row.dataset.entry));
     }));
   app.querySelectorAll("[data-open]").forEach(el =>
-    el.addEventListener("click", () => window.open(`/api/attachments/${el.dataset.open}`)));
+    el.addEventListener("click", () => window.open(docUrl(el.dataset.open))));
   app.querySelectorAll("[data-adel]").forEach(b =>
     b.addEventListener("click", async () => {
       if (confirm("Delete this document?")) { await api(`/api/attachments/${b.dataset.adel}`, { method: "DELETE" }); showCar(id); }
     }));
+  app.querySelectorAll("[data-rot]").forEach(b =>
+    b.addEventListener("click", () =>
+      rotateDialog((d.attachments || []).find(a => a.id === +b.dataset.rot), () => showCar(id))));
   // Scan runs the crop step. Pic is the same camera with none of it, because a
   // wheel or a paint defect is a whole photo with no document in it to find, and
   // it only lives here: an expense wants a receipt, not a picture of the car.
@@ -367,8 +370,10 @@ async function showCar(id, year) {
     const row = document.createElement("div");
     row.className = "entry";
     row.innerHTML = `<span class="doc-open" data-open="${att.id}">${esc(att.filename)} <span class="muted">${dmy(att.created)}</span></span>
-      <button class="danger" data-adel="${att.id}">✕</button>`;
-    $("[data-open]", row).addEventListener("click", () => window.open(`/api/attachments/${att.id}`));
+      <span class="doc-btns">${rotBtn(att)}<button class="danger" data-adel="${att.id}">✕</button></span>`;
+    $("[data-open]", row).addEventListener("click", () => window.open(docUrl(att.id)));
+    if ($("[data-rot]", row))
+      $("[data-rot]", row).addEventListener("click", () => rotateDialog(att, () => showCar(id)));
     $("[data-adel]", row).addEventListener("click", async () => {
       if (confirm("Delete this document?")) { await api(`/api/attachments/${att.id}`, { method: "DELETE" }); showCar(id); }
     });
@@ -414,6 +419,52 @@ async function showCar(id, year) {
       if (!more) showCar(id);
       else if (att) addRow(att);
     });
+}
+
+/* ---------- rotating a stored image (#43) ----------
+   A photo taken over a receipt often lands sideways, and until now it stayed
+   that way: every other path here only reads an attachment. The rotate is a
+   real rewrite on the server, so once it is saved the file itself is upright
+   and anything that opens it later — this app, a download, a thumbnail — sees
+   the same picture.
+
+   `docV` is a cache buster, not decoration. The browser has already cached
+   /api/attachments/{id}; without a changing query the rotation looks like it
+   did nothing at all, which is the same trap as the ?v= rule on app.js. */
+const docV = {};
+const docUrl = id => `/api/attachments/${id}${docV[id] ? `?v=${docV[id]}` : ""}`;
+const canRotate = att => (att.media_type || "").startsWith("image/");
+const rotBtn = att => canRotate(att) ? `<button class="ghost rot" data-rot="${att.id}" title="Rotate">↻</button>` : "";
+
+function rotateDialog(att, done) {
+  let deg = 0;
+  const dlg = document.createElement("dialog");
+  dlg.className = "rot-dlg";
+  dlg.innerHTML = `<h1>Rotate</h1>
+    <p class="hint" style="margin:0 0 8px">${esc(att.filename)}</p>
+    <div class="rot-stage"><img alt="" src="/api/attachments/${att.id}?v=${Date.now()}"></div>
+    <div class="dlg-actions">
+      <button type="button" class="ghost" id="rot-l" title="Turn left">↺</button>
+      <button type="button" class="ghost" id="rot-r" title="Turn right">↻</button>
+      <button type="button" class="ghost" id="rot-x">Cancel</button>
+      <button type="button" id="rot-ok">Save</button></div>`;
+  document.body.append(dlg);
+  const img = $("img", dlg);
+  const turn = by => { deg = (deg + by + 360) % 360; img.style.transform = `rotate(${deg}deg)`; };
+  const end = () => { dlg.close(); dlg.remove(); };
+  $("#rot-l", dlg).addEventListener("click", () => turn(-90));
+  $("#rot-r", dlg).addEventListener("click", () => turn(90));
+  $("#rot-x", dlg).addEventListener("click", end);
+  dlg.addEventListener("cancel", ev => { ev.preventDefault(); end(); });
+  $("#rot-ok", dlg).addEventListener("click", async () => {
+    if (!deg) return end();               // nothing turned, nothing to write
+    try { await api(`/api/attachments/${att.id}/rotate?degrees=${deg}`, { method: "POST" }); }
+    catch (e) { alert(e.message); return; }
+    docV[att.id] = Date.now();
+    end();
+    if (done) done();
+  });
+  dlg.showModal();
 }
 
 async function uploadDoc(path, file, name) {
@@ -594,7 +645,7 @@ function attachmentsDialog(car, entry) {
   dlg.innerHTML = `<form method="dialog"><h1>${CAT_LABELS[entry.category]} ${dmy(entry.date)} — attachments</h1>
     ${entry.attachments.map(a => `
       <div class="entry"><span class="doc-open" data-open="${a.id}">${esc(a.filename)}</span>
-      <button type="button" class="danger" data-adel="${a.id}">✕</button></div>`).join("") ||
+      <span class="doc-btns">${rotBtn(a)}<button type="button" class="danger" data-adel="${a.id}">✕</button></span></div>`).join("") ||
       '<div class="muted">Nothing attached yet.</div>'}
     <input type="file" class="att-scan" accept="image/*" capture="environment" hidden>
     <input type="file" class="att-file" accept="image/*,application/pdf" hidden>
@@ -604,7 +655,11 @@ function attachmentsDialog(car, entry) {
   document.body.append(dlg);
   dlg.addEventListener("close", () => dlg.remove());
   dlg.querySelectorAll("[data-open]").forEach(el =>
-    el.addEventListener("click", () => window.open(`/api/attachments/${el.dataset.open}`)));
+    el.addEventListener("click", () => window.open(docUrl(el.dataset.open))));
+  dlg.querySelectorAll("[data-rot]").forEach(b =>
+    b.addEventListener("click", () =>
+      rotateDialog(entry.attachments.find(a => a.id === +b.dataset.rot),
+                   () => { dlg.close("cancel"); showCar(car.id); })));
   dlg.querySelectorAll("[data-adel]").forEach(b =>
     b.addEventListener("click", async () => {
       if (!confirm("Delete this document?")) return;

--- a/static/index.html
+++ b/static/index.html
@@ -98,10 +98,18 @@ button.clip.clip-empty { opacity: .35; }
 .scan-pair img { width: 100%; height: 190px; object-fit: contain; border-radius: 10px;
                  background: rgba(128, 128, 128, .12); display: block; }
 .scan-pair figcaption { font-size: .85rem; color: var(--muted); text-align: center; margin-top: 4px; }
+/* Rotate (#43). The stage is square so a landscape photo still fits once it is
+   turned on its side, and the turn is a CSS transform until Save. */
+.doc-btns { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
+.doc-btns .rot { padding: 4px 9px; font-size: 1rem; line-height: 1; }
+.rot-stage { aspect-ratio: 1; display: grid; place-items: center; overflow: hidden;
+             border-radius: 10px; background: rgba(128, 128, 128, .12); }
+.rot-stage img { max-width: 100%; max-height: 100%; display: block;
+                 transition: transform .15s ease; }
 </style>
 </head>
 <body>
 <div id="app"></div>
-<script src="/static/app.js?v=51"></script>
+<script src="/static/app.js?v=52"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds a rotate action to a stored image attachment, so a photo that came out sideways can be turned the right way up.

Issue #43 left the placement open. This takes the stored attachment route rather than a control in the scan dialog, because it covers Scan, Pic and Attach file alike, it fixes photos that are already uploaded, and it adds no tap to the Pic path.

## What it does

A `↻` appears beside every image in the Docs and pics list and in the 📎 dialog. PDFs do not get one. Tapping it opens a small dialog with the picture, a turn left and a turn right, Cancel and Save. The preview turns with a CSS transform, so only Save talks to the server, once, with the final angle.

## Server

`POST /api/attachments/{id}/rotate?degrees=90|180|270` turns the image and writes it back.

- The format, the filename and the id all stay put. `doc_path()` derives the file name from the media type, so a re encode into another format would move the file out from under its own row.
- `exif_transpose` runs before the rotate, and the saved copy carries no orientation tag. A phone JPEG stores its orientation in EXIF, and without this a rotate would fight whatever the viewer decided to do with that tag.
- The write goes to a temp file and is moved into place, the same way an upload is stored.
- A PDF gives 422, an angle that is not 90, 180 or 270 gives 422, a missing row or a missing file gives 404.
- This is the one place the app rewrites an attachment, and the comment at the top of the attachments section now says so.

## Verified

- 34 checks in a throwaway database: each angle turns the picture the right way, proven by where a marked corner pixel lands, not just by the dimensions; four turns of 90 restore the original bytes; format, filename and id survive; the size column matches the file on disk; a JPEG carrying orientation tag 6 comes out upright with the tag gone; every refusal above; a rotate leaves other attachments byte identical and no temp files behind.
- The dialog, the list rows and the result after Save were rendered at 390 px in a real browser. A landscape photo still fits the stage once it is on its side, and reopening the dialog shows the saved orientation rather than a cached copy.
- Deployed and smoke tested on the live instance with a throwaway attachment, which was then deleted. The four real attachments are byte identical and the database is unchanged.

No version bump, no release, and the issue stays open. Ready for a look on your phone.
