### PR TITLE
Thumbnails for image attachments (#44)

### DIFF
--- a/main.py
+++ b/main.py
@@ -846,7 +846,11 @@ def car_detail(car_id: int, year: int | None = None):
         by_entry = {}
         for a in atts:
             if a["entry_id"] is not None:
-                by_entry.setdefault(a["entry_id"], []).append({"id": a["id"], "filename": a["filename"]})
+                # media_type rides along: the 📎 dialog decides from it whether a
+                # row gets a thumbnail and a rotate button, and without it every
+                # attachment there looked like a PDF.
+                by_entry.setdefault(a["entry_id"], []).append(
+                    {"id": a["id"], "filename": a["filename"], "media_type": a["media_type"]})
         return {"car": dict(car),
                 "attachments": [dict(a) for a in atts if a["entry_id"] is None],
                 "next_due": car_dues[0] if car_dues else None,
@@ -1098,6 +1102,7 @@ def delete_entry(entry_id: int):
     for att in atts:   # rows went with the FK cascade; files are ours to remove
         if os.path.isfile(doc_path(att)):
             os.remove(doc_path(att))
+        drop_thumb(att)
 
 
 @app.post("/api/cars/{car_id}/photo")
@@ -1142,6 +1147,23 @@ PIL_TYPES = {"JPEG": "image/jpeg", "PNG": "image/png", "WEBP": "image/webp", "HE
 
 def doc_path(att) -> str:
     return os.path.join(DOCS_DIR, f"{att['id']}.{DOC_EXT[att['media_type']]}")
+
+
+# A list of file names tells you nothing about which scan is which receipt
+# (issue #44), so image rows carry a small picture. It is made on first request
+# and cached beside the document, which keeps the upload path fast and means the
+# attachments already on disk need no migration.
+THUMB_PX = 200
+
+
+def thumb_path(att) -> str:
+    return os.path.join(DOCS_DIR, f"{att['id']}.thumb.jpg")
+
+
+def drop_thumb(att) -> None:
+    """Forget a cached thumbnail. Cheap: the next request draws it again."""
+    if os.path.isfile(thumb_path(att)):
+        os.remove(thumb_path(att))
 
 
 # ---- scan auto-crop (issue #19) --------------------------------------------
@@ -1380,6 +1402,38 @@ def get_attachment(att_id: int):
                         headers={"Content-Disposition": f'inline; filename="{safe}"'})
 
 
+@app.get("/api/attachments/{att_id}/thumb")
+def get_attachment_thumb(att_id: int):
+    """A small square picture of an image attachment, drawn once and cached.
+
+    A PDF gets a 404 rather than a placeholder: drawing one would mean carrying
+    a PDF rendering library, which this app deliberately does not, and the UI
+    already knows from the media type not to ask.
+    """
+    with db() as con:
+        att = con.execute("SELECT * FROM attachments WHERE id=?", (att_id,)).fetchone()
+    if not att or not os.path.isfile(doc_path(att)):
+        raise HTTPException(404, "no such attachment")
+    if att["media_type"] == "application/pdf":
+        raise HTTPException(404, "no thumbnail for a PDF")
+
+    path = thumb_path(att)
+    if not os.path.isfile(path):
+        tmp = os.path.join(DOCS_DIR, f".thumb-{pysecrets.token_hex(8)}")
+        try:
+            # _load_upright drafts the decode down to roughly what is needed and
+            # applies the orientation tag, which is the whole point of it here: a
+            # 12 MP scan must never be decoded in full just to draw 200 px.
+            im = _load_upright(doc_path(att), THUMB_PX)
+            ImageOps.fit(im, (THUMB_PX, THUMB_PX), Image.LANCZOS).save(tmp, "JPEG", quality=80)
+            os.replace(tmp, path)
+        except Exception:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            raise HTTPException(404, "no thumbnail for this file")
+    return FileResponse(path, media_type="image/jpeg")
+
+
 ROTATIONS = {90: Image.Transpose.ROTATE_270, 180: Image.Transpose.ROTATE_180,
              270: Image.Transpose.ROTATE_90}   # clockwise degrees -> Pillow's anticlockwise names
 
@@ -1419,6 +1473,7 @@ def rotate_attachment(att_id: int, degrees: int = 90):
         out.save(tmp, format=fmt, **opts)
         size = os.path.getsize(tmp)
         os.replace(tmp, path)
+        drop_thumb(att)        # or the list keeps showing the old way up (#44)
     except HTTPException:
         raise
     except Exception:
@@ -1440,6 +1495,7 @@ def delete_attachment(att_id: int):
         con.execute("DELETE FROM attachments WHERE id=?", (att_id,))
     if os.path.isfile(doc_path(att)):
         os.remove(doc_path(att))
+    drop_thumb(att)
 
 
 @app.get("/api/dues")

--- a/static/app.js
+++ b/static/app.js
@@ -287,7 +287,7 @@ async function showCar(id, year) {
     </div>` : ""}
     <div class="card"><div class="muted" style="margin-bottom:4px">Docs and pics</div>
       <div id="doc-list">${(d.attachments || []).map(a => `
-        <div class="entry"><span class="doc-open" data-open="${a.id}">${esc(a.filename)} <span class="muted">${dmy(a.created)}</span></span>
+        <div class="entry"><span class="doc-open" data-open="${a.id}">${docThumb(a)}<span>${esc(a.filename)} <span class="muted">${dmy(a.created)}</span></span></span>
         <span class="doc-btns">${rotBtn(a)}<button class="danger" data-adel="${a.id}">✕</button></span></div>`).join("") ||
         '<div class="muted" id="doc-empty">Nothing here yet — certs, receipts and reports live here, and so do pictures of the car.</div>'}</div>
       <div class="row" style="gap:10px;margin-top:8px">
@@ -369,7 +369,7 @@ async function showCar(id, year) {
     if (empty) empty.remove();
     const row = document.createElement("div");
     row.className = "entry";
-    row.innerHTML = `<span class="doc-open" data-open="${att.id}">${esc(att.filename)} <span class="muted">${dmy(att.created)}</span></span>
+    row.innerHTML = `<span class="doc-open" data-open="${att.id}">${docThumb(att)}<span>${esc(att.filename)} <span class="muted">${dmy(att.created)}</span></span></span>
       <span class="doc-btns">${rotBtn(att)}<button class="danger" data-adel="${att.id}">✕</button></span>`;
     $("[data-open]", row).addEventListener("click", () => window.open(docUrl(att.id)));
     if ($("[data-rot]", row))
@@ -435,6 +435,14 @@ const docV = {};
 const docUrl = id => `/api/attachments/${id}${docV[id] ? `?v=${docV[id]}` : ""}`;
 const canRotate = att => (att.media_type || "").startsWith("image/");
 const rotBtn = att => canRotate(att) ? `<button class="ghost rot" data-rot="${att.id}" title="Rotate">↻</button>` : "";
+
+/* A row of file names never says which scan is which receipt (#44). Images get
+   a small picture, drawn and cached by the server on first request; a PDF keeps
+   an icon in the same slot so the rows still line up. The cache buster is the
+   one from the rotate above, so straightening a photo refreshes its picture. */
+const docThumb = att => canRotate(att)
+  ? `<img class="doc-thumb" loading="lazy" alt="" src="/api/attachments/${att.id}/thumb${docV[att.id] ? `?v=${docV[att.id]}` : ""}">`
+  : `<span class="doc-thumb doc-thumb-pdf">📄</span>`;
 
 function rotateDialog(att, done) {
   let deg = 0;
@@ -644,7 +652,7 @@ function attachmentsDialog(car, entry) {
   const dlg = document.createElement("dialog");
   dlg.innerHTML = `<form method="dialog"><h1>${CAT_LABELS[entry.category]} ${dmy(entry.date)} — attachments</h1>
     ${entry.attachments.map(a => `
-      <div class="entry"><span class="doc-open" data-open="${a.id}">${esc(a.filename)}</span>
+      <div class="entry"><span class="doc-open" data-open="${a.id}">${docThumb(a)}<span>${esc(a.filename)}</span></span>
       <span class="doc-btns">${rotBtn(a)}<button type="button" class="danger" data-adel="${a.id}">✕</button></span></div>`).join("") ||
       '<div class="muted">Nothing attached yet.</div>'}
     <input type="file" class="att-scan" accept="image/*" capture="environment" hidden>

--- a/static/index.html
+++ b/static/index.html
@@ -106,10 +106,17 @@ button.clip.clip-empty { opacity: .35; }
              border-radius: 10px; background: rgba(128, 128, 128, .12); }
 .rot-stage img { max-width: 100%; max-height: 100%; display: block;
                  transition: transform .15s ease; }
+/* Thumbnails (#44). The doc row's tappable half becomes a flex line so the
+   picture and the file name sit together; a PDF's icon takes the same box so
+   rows with and without a picture line up. */
+.doc-open { display: flex; align-items: center; gap: 9px; min-width: 0; }
+.doc-thumb { width: 38px; height: 38px; flex-shrink: 0; border-radius: 8px;
+             object-fit: cover; background: rgba(128, 128, 128, .12); display: block; }
+.doc-thumb-pdf { display: grid; place-items: center; font-size: 1.05rem; }
 </style>
 </head>
 <body>
 <div id="app"></div>
-<script src="/static/app.js?v=52"></script>
+<script src="/static/app.js?v=53"></script>
 </body>
 </html>


### PR DESCRIPTION
Image rows in the Docs and pics list and in the 📎 dialog now carry a small picture, so a list of scans is something you can read at a glance instead of a column of near identical file names.

## What it does

`GET /api/attachments/{id}/thumb` returns a small square JPEG. It is drawn on **first request** and cached beside the document as `{id}.thumb.jpg`, which is what lets attachments already on disk get pictures with no migration and leaves the upload path exactly as fast as it was.

- Reuses `_load_upright()`, which drafts the decode down to roughly the size needed and applies the orientation tag. A 12 MP scan is never decoded in full to draw 200 px.
- Square crop, the same treatment the car photo thumbnail already gets, so rows line up instead of stepping in and out with every aspect ratio.
- A PDF gets a 404 rather than a placeholder, since drawing one would mean carrying a PDF rendering library this app deliberately does not have. The row shows a document icon in the same box, so the rows still line up.
- **Rotating or deleting an attachment drops the cached thumbnail**, including when the entry that owns it is deleted. Without that a straightened receipt would keep its old sideways picture for good.

## A bug this found, from the rotate work

The paperclip dialog builds its rows from the per entry attachment list in the car payload, and that list carried only `id` and `filename`. With no media type, every attachment there looked like a PDF: no thumbnail, and **no rotate button either**, which means the rotate added in #43 has been invisible in that dialog since it shipped. The field now rides along, and there is a test for it. Rendering the dialog is what caught this; the tests were all green.

## Verified

- 30 checks in a throwaway database: drawn once and served from cache on the second request, proven by the file's modification time; square and capped at 200 px; portrait, landscape and PNG sources; a JPEG carrying an orientation tag comes out the right way up, proven from the pixels; PDF, unknown id and missing file all 404; a rotate drops the cached picture and the next request draws a different one; deleting an attachment and deleting its entry both take the thumbnail with them; no temp files left behind; and the per entry rows carry the media type. The suite fails against the current main, and the media type check fails against a copy of this branch with just that one line reverted.
- Both lists rendered at 390 px in a real browser, with a mix of images and a PDF, before and after a rotate.
- Deployed to the live instance: thumbnails drawn for the four real attachments, documents unchanged, database unchanged.

No version bump, no release, and #44 stays open. Ready for your phone.
