### PR TITLE
Give an image a note, shown instead of the file name (#47)

### DIFF
--- a/main.py
+++ b/main.py
@@ -444,7 +444,8 @@ def init_db():
           filename TEXT NOT NULL,
           media_type TEXT NOT NULL,
           size INTEGER NOT NULL,
-          created TEXT NOT NULL
+          created TEXT NOT NULL,
+          note TEXT NOT NULL DEFAULT ''
         );
         CREATE INDEX IF NOT EXISTS idx_attachments_entry ON attachments(entry_id);
         CREATE TABLE IF NOT EXISTS settings (
@@ -468,6 +469,10 @@ def init_db():
         for col in ("corners", "tyre_size", "tyre_brand", "tread_mm", "period"):
             if col not in have_e:
                 con.execute(f"ALTER TABLE entries ADD COLUMN {col} TEXT DEFAULT ''")
+        have_a = {r["name"] for r in con.execute("PRAGMA table_info(attachments)")}
+        for col in ("note",):   # issue #47; the first column this table has gained
+            if col not in have_a:
+                con.execute(f"ALTER TABLE attachments ADD COLUMN {col} TEXT NOT NULL DEFAULT ''")
         if con.execute("SELECT COUNT(*) c FROM cars").fetchone()["c"] == 0:
             con.execute("INSERT INTO cars (name) VALUES ('My Car')")
 
@@ -841,7 +846,7 @@ def car_detail(car_id: int, year: int | None = None):
             "FROM entries WHERE car_id=? AND category IN ('service','tyres','repair') "
             "ORDER BY date DESC, id DESC", (car_id,))]
         atts = con.execute(
-            "SELECT id, entry_id, filename, media_type, size, created FROM attachments "
+            "SELECT id, entry_id, filename, media_type, size, created, note FROM attachments "
             "WHERE car_id=? ORDER BY created DESC, id DESC", (car_id,)).fetchall()
         by_entry = {}
         for a in atts:
@@ -850,7 +855,8 @@ def car_detail(car_id: int, year: int | None = None):
                 # row gets a thumbnail and a rotate button, and without it every
                 # attachment there looked like a PDF.
                 by_entry.setdefault(a["entry_id"], []).append(
-                    {"id": a["id"], "filename": a["filename"], "media_type": a["media_type"]})
+                    {"id": a["id"], "filename": a["filename"], "media_type": a["media_type"],
+                     "note": a["note"]})
         return {"car": dict(car),
                 "attachments": [dict(a) for a in atts if a["entry_id"] is None],
                 "next_due": car_dues[0] if car_dues else None,
@@ -1400,6 +1406,32 @@ def get_attachment(att_id: int):
     safe = att["filename"].replace('"', "")
     return FileResponse(doc_path(att), media_type=att["media_type"],
                         headers={"Content-Disposition": f'inline; filename="{safe}"'})
+
+
+class AttachmentPatch(BaseModel):
+    note: str = ""
+
+
+MAX_NOTE = 80
+
+
+@app.patch("/api/attachments/{att_id}")
+def patch_attachment(att_id: int, patch: AttachmentPatch):
+    """Name an attachment (issue #47).
+
+    A phone picks the file name, so a list of scans reads as `scan.jpg`,
+    `scan-2.jpg` and nothing else. The note stands in for that name in the
+    lists; the file name itself is never touched, because it is what a download
+    is called and the only record of what the phone actually produced.
+    """
+    note = " ".join(patch.note.split())      # collapse whitespace; blank clears it
+    if len(note) > MAX_NOTE:
+        raise HTTPException(422, f"a note is at most {MAX_NOTE} characters")
+    with db() as con:
+        if not con.execute("SELECT 1 FROM attachments WHERE id=?", (att_id,)).fetchone():
+            raise HTTPException(404, "no such attachment")
+        con.execute("UPDATE attachments SET note=? WHERE id=?", (note, att_id))
+        return dict(con.execute("SELECT * FROM attachments WHERE id=?", (att_id,)).fetchone())
 
 
 @app.get("/api/attachments/{att_id}/thumb")

--- a/static/app.js
+++ b/static/app.js
@@ -287,7 +287,7 @@ async function showCar(id, year) {
     </div>` : ""}
     <div class="card"><div class="muted" style="margin-bottom:4px">Docs and pics</div>
       <div id="doc-list">${(d.attachments || []).map(a => `
-        <div class="entry"><span class="doc-open" data-open="${a.id}">${docThumb(a)}<span>${esc(a.filename)} <span class="muted">${dmy(a.created)}</span></span></span>
+        <div class="entry"><span class="doc-open" data-open="${a.id}" title="${esc(a.filename)}">${docThumb(a)}<span>${docLabel(a)} <span class="muted">${dmy(a.created)}</span></span></span>
         <span class="doc-btns">${rotBtn(a)}<button class="danger" data-adel="${a.id}">✕</button></span></div>`).join("") ||
         '<div class="muted" id="doc-empty">Nothing here yet — certs, receipts and reports live here, and so do pictures of the car.</div>'}</div>
       <div class="row" style="gap:10px;margin-top:8px">
@@ -349,7 +349,7 @@ async function showCar(id, year) {
     }));
   app.querySelectorAll("[data-rot]").forEach(b =>
     b.addEventListener("click", () =>
-      rotateDialog((d.attachments || []).find(a => a.id === +b.dataset.rot), () => showCar(id))));
+      imageDialog((d.attachments || []).find(a => a.id === +b.dataset.rot), () => showCar(id))));
   // Scan runs the crop step. Pic is the same camera with none of it, because a
   // wheel or a paint defect is a whole photo with no document in it to find, and
   // it only lives here: an expense wants a receipt, not a picture of the car.
@@ -369,11 +369,11 @@ async function showCar(id, year) {
     if (empty) empty.remove();
     const row = document.createElement("div");
     row.className = "entry";
-    row.innerHTML = `<span class="doc-open" data-open="${att.id}">${docThumb(att)}<span>${esc(att.filename)} <span class="muted">${dmy(att.created)}</span></span></span>
+    row.innerHTML = `<span class="doc-open" data-open="${att.id}" title="${esc(att.filename)}">${docThumb(att)}<span>${docLabel(att)} <span class="muted">${dmy(att.created)}</span></span></span>
       <span class="doc-btns">${rotBtn(att)}<button class="danger" data-adel="${att.id}">✕</button></span>`;
     $("[data-open]", row).addEventListener("click", () => window.open(docUrl(att.id)));
     if ($("[data-rot]", row))
-      $("[data-rot]", row).addEventListener("click", () => rotateDialog(att, () => showCar(id)));
+      $("[data-rot]", row).addEventListener("click", () => imageDialog(att, () => showCar(id)));
     $("[data-adel]", row).addEventListener("click", async () => {
       if (confirm("Delete this document?")) { await api(`/api/attachments/${att.id}`, { method: "DELETE" }); showCar(id); }
     });
@@ -434,23 +434,29 @@ async function showCar(id, year) {
 const docV = {};
 const docUrl = id => `/api/attachments/${id}${docV[id] ? `?v=${docV[id]}` : ""}`;
 const canRotate = att => (att.media_type || "").startsWith("image/");
-const rotBtn = att => canRotate(att) ? `<button class="ghost rot" data-rot="${att.id}" title="Rotate">↻</button>` : "";
+const rotBtn = att => canRotate(att) ? `<button class="ghost rot" data-rot="${att.id}" title="Rotate or name this picture">↻</button>` : "";
 
 /* A row of file names never says which scan is which receipt (#44). Images get
    a small picture, drawn and cached by the server on first request; a PDF keeps
    an icon in the same slot so the rows still line up. The cache buster is the
    one from the rotate above, so straightening a photo refreshes its picture. */
+/* A phone names the file, so a row reads `scan.jpg` unless you say otherwise
+   (#47). The note stands in for the name in every list; the real file name is
+   still on the row as a tooltip, and in full in the image dialog. */
+const docLabel = att => esc(att.note || att.filename);
 const docThumb = att => canRotate(att)
   ? `<img class="doc-thumb" loading="lazy" alt="" src="/api/attachments/${att.id}/thumb${docV[att.id] ? `?v=${docV[att.id]}` : ""}">`
   : `<span class="doc-thumb doc-thumb-pdf">📄</span>`;
 
-function rotateDialog(att, done) {
+function imageDialog(att, done) {
   let deg = 0;
   const dlg = document.createElement("dialog");
   dlg.className = "rot-dlg";
-  dlg.innerHTML = `<h1>Rotate</h1>
+  dlg.innerHTML = `<h1>Picture</h1>
     <p class="hint" style="margin:0 0 8px">${esc(att.filename)}</p>
     <div class="rot-stage"><img alt="" src="/api/attachments/${att.id}?v=${Date.now()}"></div>
+    <label class="rot-note">Note<input id="rot-note" type="text" maxlength="80"
+      placeholder="Shown instead of the file name" value="${esc(att.note || "")}"></label>
     <div class="dlg-actions">
       <button type="button" class="ghost" id="rot-l" title="Turn left">↺</button>
       <button type="button" class="ghost" id="rot-r" title="Turn right">↻</button>
@@ -458,6 +464,8 @@ function rotateDialog(att, done) {
       <button type="button" id="rot-ok">Save</button></div>`;
   document.body.append(dlg);
   const img = $("img", dlg);
+  const noteBox = $("#rot-note", dlg);
+  const was = att.note || "";
   const turn = by => { deg = (deg + by + 360) % 360; img.style.transform = `rotate(${deg}deg)`; };
   const end = () => { dlg.close(); dlg.remove(); };
   $("#rot-l", dlg).addEventListener("click", () => turn(-90));
@@ -465,10 +473,16 @@ function rotateDialog(att, done) {
   $("#rot-x", dlg).addEventListener("click", end);
   dlg.addEventListener("cancel", ev => { ev.preventDefault(); end(); });
   $("#rot-ok", dlg).addEventListener("click", async () => {
-    if (!deg) return end();               // nothing turned, nothing to write
-    try { await api(`/api/attachments/${att.id}/rotate?degrees=${deg}`, { method: "POST" }); }
-    catch (e) { alert(e.message); return; }
-    docV[att.id] = Date.now();
+    const note = noteBox.value.trim();
+    if (!deg && note === was) return end();   // nothing changed, nothing to write
+    try {
+      if (deg) await api(`/api/attachments/${att.id}/rotate?degrees=${deg}`, { method: "POST" });
+      if (note !== was)
+        await api(`/api/attachments/${att.id}`, {
+          method: "PATCH", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ note }) });
+    } catch (e) { alert(e.message); return; }
+    if (deg) docV[att.id] = Date.now();
     end();
     if (done) done();
   });
@@ -652,7 +666,7 @@ function attachmentsDialog(car, entry) {
   const dlg = document.createElement("dialog");
   dlg.innerHTML = `<form method="dialog"><h1>${CAT_LABELS[entry.category]} ${dmy(entry.date)} — attachments</h1>
     ${entry.attachments.map(a => `
-      <div class="entry"><span class="doc-open" data-open="${a.id}">${docThumb(a)}<span>${esc(a.filename)}</span></span>
+      <div class="entry"><span class="doc-open" data-open="${a.id}" title="${esc(a.filename)}">${docThumb(a)}<span>${docLabel(a)}</span></span>
       <span class="doc-btns">${rotBtn(a)}<button type="button" class="danger" data-adel="${a.id}">✕</button></span></div>`).join("") ||
       '<div class="muted">Nothing attached yet.</div>'}
     <input type="file" class="att-scan" accept="image/*" capture="environment" hidden>
@@ -666,7 +680,7 @@ function attachmentsDialog(car, entry) {
     el.addEventListener("click", () => window.open(docUrl(el.dataset.open))));
   dlg.querySelectorAll("[data-rot]").forEach(b =>
     b.addEventListener("click", () =>
-      rotateDialog(entry.attachments.find(a => a.id === +b.dataset.rot),
+      imageDialog(entry.attachments.find(a => a.id === +b.dataset.rot),
                    () => { dlg.close("cancel"); showCar(car.id); })));
   dlg.querySelectorAll("[data-adel]").forEach(b =>
     b.addEventListener("click", async () => {

--- a/static/index.html
+++ b/static/index.html
@@ -113,10 +113,12 @@ button.clip.clip-empty { opacity: .35; }
 .doc-thumb { width: 38px; height: 38px; flex-shrink: 0; border-radius: 8px;
              object-fit: cover; background: rgba(128, 128, 128, .12); display: block; }
 .doc-thumb-pdf { display: grid; place-items: center; font-size: 1.05rem; }
+.rot-note { display: block; margin-top: 10px; font-size: .85rem; color: var(--muted); }
+.rot-note input { margin-top: 4px; }
 </style>
 </head>
 <body>
 <div id="app"></div>
-<script src="/static/app.js?v=53"></script>
+<script src="/static/app.js?v=54"></script>
 </body>
 </html>


### PR DESCRIPTION
An attachment can now carry a short note, and that note stands in for the file name in the lists. With no note the row reads exactly as it does today.

A phone picks the file name, not you, so a car page full of scans reads `scan.jpg`, `scan-2.jpg`, `IMG_20260813_114233.jpg`. Thumbnails helped you spot a picture; this is what lets you tell two receipts apart.

## Your three answers, and what they mean here

- **Where you type it:** the rotate dialog becomes a **Picture** dialog with a note field. No new button on the row, and the image is in front of you while you name it. Save applies the turn and the note together.
- **Scope:** the note replaces the file name in **both** lists, the car page and the paperclip dialog.
- **At attach time:** no. The camera paths stay exactly as short as they are.

## Details

- `note` is added to `attachments`, both in the create and through a migration loop, the first that table has had. It runs on existing databases and defaults to empty.
- `PATCH /api/attachments/{id}` is the first endpoint that edits an attachment. Whitespace is collapsed, an empty note clears it, and it is capped at 80 characters so a row cannot be made unreadable.
- **The file name is never touched.** It names a download and it is the only record of what the phone produced. It stays on the row as a tooltip and in full under the heading of the Picture dialog.
- The per entry attachment rows carry the note as well, which is the same trimmed payload that hid the rotate button for a release. There is a test for it, and it fails when that one line is reverted.

## Verified

- 23 checks, including the migration landing on a database built by the **shipped release** with row counts unchanged and an old attachment coming back with an empty note; whitespace collapsing; blank and omitted both clearing; the cap accepted at the limit and refused one over, with the stored note unchanged by the refusal; a note surviving a rotate; naming leaving the file bytes alone; a PDF taking a note too; and the per entry rows carrying it.
- The suites for the rotate and the thumbnails both still pass.
- Rendered at 390 px: the dialog with a note typed, the car page list with one named and one unnamed attachment, and the paperclip dialog.
- Deployed to the live instance: the column landed, all four attachments have an empty note, documents are md5 identical and the database checks out.

No version bump, no release, and the issue stays open.
