### PR TITLE
Fix L/100km, add fuel cost per 100 km, require litres on fuel entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ cost per year, per km, and what's due next?*
 ## Features
 
 **Logging, the way it really happens**
-- Fuel fills are amount (€) + odometer; litres optional (€/L derived when
-  given). Insurance, motor tax, NCT and servicing are dated amounts, freely
+- Fuel fills are amount (€) + odometer + litres (€/L is derived from the
+  first two). Insurance, motor tax, NCT and servicing are dated amounts, freely
   backdatable — start mid-year and enter January's insurance on day one.
 - Standalone mileage entries: log the odometer any time; the newest reading
   shows on the car's page and feeds the stats.

--- a/examples/car_costs.yaml
+++ b/examples/car_costs.yaml
@@ -108,6 +108,23 @@ template:
              | selectattr('id','eq',1) | first %}
           {{ c.l_per_100km }}
 
+      # Fuel spend only, and it always has a value: it needs just the amount and
+      # the odometer. Note this moves with the price at the pump as well as with
+      # the driving, unlike the L/100km above.
+      - name: Family car fuel cost per 100 km
+        unique_id: car_costs_car1_eur100km
+        unit_of_measurement: "€/100km"
+        availability: >-
+          {% set c = (state_attr('sensor.car_costs_summary','cars') or [])
+             | selectattr('id','eq',1) | first | default(none) %}
+          {{ c is not none and c.eur_per_100km is not none }}
+        state: >-
+          {% set c = (state_attr('sensor.car_costs_summary','cars') or [])
+             | selectattr('id','eq',1) | first %}
+          {{ c.eur_per_100km }}
+
+      # Everything, not just fuel: insurance, tax, NCT, repairs. Different scope
+      # and a different unit to the sensor above, so keep the names distinct.
       - name: Family car cost per km
         unique_id: car_costs_car1_cost_per_km
         unit_of_measurement: "€/km"

--- a/main.py
+++ b/main.py
@@ -718,22 +718,49 @@ def year_summary(con, car_id: int, year: int):
 
 
 def fuel_stats(con, car_id: int):
-    """L/100km from consecutive fuel fills with odometer readings."""
+    """Consumption and fuel cost per 100 km, from consecutive fills.
+
+    Both are pooled rather than averaged per leg, so a 40 km leg cannot pull as
+    hard as a 700 km one.
+
+    A leg is measured by the litres of the fill that ENDS it, which is what
+    replaced the fuel burned over it. The opening fill's volume is irrelevant,
+    only that a fill happened at that odometer. Litres were optional until
+    2026-08-13, so a fill may have none: that costs its own leg and breaks the
+    run, but the next leg still starts cleanly from it. Dropping such a fill from
+    the list instead, as this once did, credits its distance to the next fill's
+    tank and understates consumption badly.
+
+    The cost figure needs only the amount and the odometer, both mandatory, so it
+    always spans every fill.
+    """
     fills = con.execute(
-        "SELECT date, odometer, litres, price_per_litre FROM entries "
-        "WHERE car_id=? AND category='fuel' AND odometer IS NOT NULL AND litres IS NOT NULL "
+        "SELECT date, odometer, litres, cost FROM entries "
+        "WHERE car_id=? AND category='fuel' AND odometer IS NOT NULL "
         "ORDER BY odometer", (car_id,)).fetchall()
-    legs = []
+    best_litres = best_dist = run_litres = run_dist = 0.0
+    spend = spend_dist = 0.0
     for prev, cur in zip(fills, fills[1:]):
         dist = cur["odometer"] - prev["odometer"]
-        if dist > 0:
-            legs.append(100.0 * cur["litres"] / dist)
+        if dist <= 0:                             # a corrected odometer, not a leg
+            run_litres = run_dist = 0.0
+            continue
+        spend += cur["cost"]
+        spend_dist += dist
+        if cur["litres"] is None:
+            run_litres = run_dist = 0.0           # this leg's burn is unknown, so it breaks the run
+            continue
+        run_litres += cur["litres"]
+        run_dist += dist
+        if run_dist > best_dist:
+            best_litres, best_dist = run_litres, run_dist
     last = con.execute(
         "SELECT price_per_litre FROM entries WHERE car_id=? AND category='fuel' "
         "AND price_per_litre IS NOT NULL ORDER BY date DESC, id DESC LIMIT 1",
         (car_id,)).fetchone()
     return {
-        "l_per_100km": round(sum(legs) / len(legs), 1) if legs else None,
+        "l_per_100km": round(100.0 * best_litres / best_dist, 1) if best_dist else None,
+        "eur_per_100km": round(100.0 * spend / spend_dist, 2) if spend_dist else None,
         "last_price_per_litre": last["price_per_litre"] if last else None,
     }
 
@@ -942,6 +969,10 @@ def validate_entry(e: EntryNew):
             raise HTTPException(422, "amount is required for a fuel entry")
         if e.odometer is None:
             raise HTTPException(422, "odometer reading is required for a fuel entry")
+        # Compulsory since 2026-08-13. Older fills may have none; those stay as they are
+        # and break the L/100km run rather than being guessed at.
+        if e.litres is None:
+            raise HTTPException(422, "litres are required for a fuel entry")
     if cost is None:
         raise HTTPException(422, "cost is required (or litres+price / kwh+price for fuel/charge)")
     return d, cost, baseline_tread
@@ -1560,7 +1591,8 @@ def summary(year: int | None = None, include_archived: bool = False):
                 "ev_enabled": car["ev_enabled"],
                 "total": s["total"], "by_category": s["by_category"],
                 "km_driven": s["km_driven"], "cost_per_km": s["cost_per_km"],
-                "l_per_100km": f["l_per_100km"], "last_price_per_litre": f["last_price_per_litre"],
+                "l_per_100km": f["l_per_100km"], "eur_per_100km": f["eur_per_100km"],
+                "last_price_per_litre": f["last_price_per_litre"],
                 "current_odo": cur, "next_due": due_items[0] if due_items else None,
             })
             for it in due_items:

--- a/main.py
+++ b/main.py
@@ -718,49 +718,51 @@ def year_summary(con, car_id: int, year: int):
 
 
 def fuel_stats(con, car_id: int):
-    """Consumption and fuel cost per 100 km, from consecutive fills.
+    """Consumption and fuel cost per 100 km, pooled over the whole span of fills.
 
-    Both are pooled rather than averaged per leg, so a 40 km leg cannot pull as
-    hard as a 700 km one.
+    EVERY fill counts, including the first, over the distance from the first
+    odometer to the last. The usual convention excludes the first fill, on the
+    grounds that its fuel was already in the tank when measuring started. That
+    only holds when the tank sits at the same level at both ends, and it is
+    catastrophic over a short history: with two fills it discards most of the
+    fuel bought while still counting all of the distance, which is how this once
+    reported 1.5 L/100km for a diesel Focus.
 
-    A leg is measured by the litres of the fill that ENDS it, which is what
-    replaced the fuel burned over it. The opening fill's volume is irrelevant,
-    only that a fill happened at that odometer. Litres were optional until
-    2026-08-13, so a fill may have none: that costs its own leg and breaks the
-    run, but the next leg still starts cleanly from it. Dropping such a fill from
-    the list instead, as this once did, credits its distance to the next fill's
-    tank and understates consumption badly.
+    Counting everything has the opposite bias, overstating by whatever is still
+    in the tank unburned, but that is bounded by tank size and shrinks as the
+    distance grows. The two conventions converge after enough fills.
 
-    The cost figure needs only the amount and the odometer, both mandatory, so it
-    always spans every fill.
+    Litres were optional until 2026-08-13, so an older fill may have none. Such a
+    fill breaks the consumption run: the longest run of consecutive fills that
+    ALL carry litres wins. The cost figure needs only the amount and the
+    odometer, both mandatory, so it always spans every fill.
     """
     fills = con.execute(
         "SELECT date, odometer, litres, cost FROM entries "
         "WHERE car_id=? AND category='fuel' AND odometer IS NOT NULL "
         "ORDER BY odometer", (car_id,)).fetchall()
-    best_litres = best_dist = run_litres = run_dist = 0.0
-    spend = spend_dist = 0.0
-    for prev, cur in zip(fills, fills[1:]):
-        dist = cur["odometer"] - prev["odometer"]
-        if dist <= 0:                             # a corrected odometer, not a leg
-            run_litres = run_dist = 0.0
+    spend = sum(f["cost"] for f in fills)
+    spend_dist = fills[-1]["odometer"] - fills[0]["odometer"] if len(fills) > 1 else 0.0
+
+    best_litres = best_dist = 0.0                 # longest run of fills that all have litres
+    run = []
+    for f in list(fills) + [None]:
+        if f is not None and f["litres"] is not None:
+            run.append(f)
             continue
-        spend += cur["cost"]
-        spend_dist += dist
-        if cur["litres"] is None:
-            run_litres = run_dist = 0.0           # this leg's burn is unknown, so it breaks the run
-            continue
-        run_litres += cur["litres"]
-        run_dist += dist
-        if run_dist > best_dist:
-            best_litres, best_dist = run_litres, run_dist
+        if len(run) > 1:
+            dist = run[-1]["odometer"] - run[0]["odometer"]
+            if dist > best_dist:
+                best_litres = sum(r["litres"] for r in run)
+                best_dist = dist
+        run = []
     last = con.execute(
         "SELECT price_per_litre FROM entries WHERE car_id=? AND category='fuel' "
         "AND price_per_litre IS NOT NULL ORDER BY date DESC, id DESC LIMIT 1",
         (car_id,)).fetchone()
     return {
         "l_per_100km": round(100.0 * best_litres / best_dist, 1) if best_dist else None,
-        "eur_per_100km": round(100.0 * spend / spend_dist, 2) if spend_dist else None,
+        "eur_per_100km": round(100.0 * spend / spend_dist, 2) if spend_dist > 0 else None,
         "last_price_per_litre": last["price_per_litre"] if last else None,
     }
 

--- a/static/app.js
+++ b/static/app.js
@@ -69,6 +69,7 @@ async function showList() {
           (c.reg ? `<span class="reg">${esc(c.reg)}</span>` : "") +
         `</span><span class="big">${eur(c.summary.total)}</span></div>
         <div class="row muted"><span>${c.fuel.last_price_per_litre ? "last fill " + c.fuel.last_price_per_litre.toFixed(3) + " €/L" : "no fills yet"}</span>
+        <span>${c.fuel.eur_per_100km ? "fuel " + eur(c.fuel.eur_per_100km) + "/100km" : ""}</span>
         <span>${c.fuel.l_per_100km ? c.fuel.l_per_100km + " L/100km" : ""}</span></div>
       </div>`).join("");
   const all = await api("/api/cars?include_archived=true");
@@ -928,7 +929,7 @@ function entryDialog(car, cat, entry) {
   const unitFields = isFuel ? `
       <label>Amount (€)</label><input name="cost" type="number" step="0.01" inputmode="decimal" required>
       <label>Odometer (km)</label><input name="odometer" type="number" step="1" inputmode="numeric" required>
-      <label>Litres (optional)</label><input name="litres" type="number" step="0.01" inputmode="decimal">
+      <label>Litres</label><input name="litres" type="number" step="0.01" inputmode="decimal" required>
       <div class="hint" id="calc"></div>`
     : isCharge ? `
       <label>Odometer (km)</label><input name="odometer" type="number" step="1" inputmode="numeric">

--- a/static/index.html
+++ b/static/index.html
@@ -119,6 +119,6 @@ button.clip.clip-empty { opacity: .35; }
 </head>
 <body>
 <div id="app"></div>
-<script src="/static/app.js?v=55"></script>
+<script src="/static/app.js?v=56"></script>
 </body>
 </html>


### PR DESCRIPTION
Addresses #50.

### The bug

`fuel_stats` selected fuel rows with `AND litres IS NOT NULL`. A fill with an odometer and an amount but no litres was removed from the list entirely, so the fills either side were treated as consecutive and one tank of fuel was credited with two tanks of distance. One car read 2.4 L/100km.

### What changed

**Every fill counts, including the first**, over the distance from the first odometer to the last. The usual convention excludes the first fill, on the grounds that its fuel was already in the tank when measuring started. That only holds when the tank sits at the same level at both ends, and over a short history it is catastrophic: with two fills it discards most of the fuel bought while still counting all of the distance. Counting everything has the opposite bias, overstating by whatever is still in the tank unburned, but that is bounded by tank size and shrinks as the distance grows.

**Both figures are pooled over the span rather than averaged per leg.** The old code averaged leg percentages equally, so a 40 km leg counted as much as a 700 km one, and a short leg is mostly tank level noise.

**A fill with no litres breaks the consumption run** instead of being dropped from the list. The longest run of consecutive fills that all carry litres wins.

**New `eur_per_100km`.** Fuel spend over distance. It needs only the amount and the odometer, both mandatory, so it always has a value and no fill is ever excluded. Shown on the car card as `fuel EUR/100km`, labelled so it is not confused with the wider `cost_per_km` on the summary view, which is a different scope and a different unit.

**Litres are now required on a fuel entry**, front end and back end. Existing fills without them are left alone.

`l_per_100km` keeps its name and unit, so the Home Assistant template sensors in `examples/car_costs.yaml` need no change. An example sensor for the new field is added alongside.

### Results on my data

The two cars are near identical, same engine and body, so their figures should be close. Before, they were not:

| | before | after |
|---|---|---|
| car 1 L/100km | 2.4 | blank |
| car 1 fuel EUR/100km | n/a | **13.61** |
| car 2 L/100km | 1.5 | **7.4** |
| car 2 fuel EUR/100km | n/a | **13.78** |

The two cost figures now agree within 1.2 percent. Car 2's 7.4 L/100km at 1.918 a litre works out at 14.20 per 100 km, which lands on its own cost figure, so three independent numbers agree.

Car 1 goes blank on L/100km because its only fill without litres sits second of three, leaving no run of two consecutive fills that both carry litres. Blank is correct there: the fuel burned over that stretch is genuinely unknown and will not be guessed at. Its cost figure is unaffected, which is the point of having it.

### Testing

Eight cases run against the new code and against `main`: no fills, one fill, a clean pair, a gap mid history, every fill missing litres, an out of order odometer, two fills at the same odometer, and a gap with runs of different length either side. The gap case returns 2.4 on `main` and blank here, so the result is attributable to the change.

Also checked: a POST with no litres returns 422, the rendered card was screenshotted for both cars, and `?v=` is bumped so the browser picks up the new `app.js`.
